### PR TITLE
Add external to build

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 FLAGS = -use-ocamlfind -no-links -no-hygiene -cflags="-warn-error +a"
-INCLUDES = . parser analysis annotated ast test service language_server command command/server %VERSION%
+INCLUDES = . parser analysis annotated ast test service language_server command command/server external %VERSION%
 BUILD = ocamlbuild $(FLAGS) $(addprefix -I , $(INCLUDES))
 
 TEST_FLAGS = -runner sequential


### PR DESCRIPTION
Build error without `external`:

```
File "ast/astStatement.ml", line 289, characters 41-74:
Error: Unbound module Recognized
```