### PR TITLE
Add pipsi install instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,13 @@ pyre --source-directory path/to/project/root
 ```
 if you'd like to specify the path instead.
 
+Alternatively, install pyre via
+[pipsi](https://github.com/mitsuhiko/pipsi) to have a single
+system-wide install instead of one per virtual env:
+```
+pipsi install pyre-check
+```
+
 # Building from Source
 
 These instructions are known to work on Mac OS X (tested on High


### PR DESCRIPTION
Hey all - in my experience, installing dev tooling like linters or type checkers like pyre system-wide via [pipsi](https://github.com/mitsuhiko/pipsi) vs once per project virtual environment has made it easier to always stay on the latest release everywhere.  I've added pipsi install instructions for others interested in a similar setup.