### PR TITLE
[setup] Fix error checking in setup.sh script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -107,7 +107,7 @@ opam install --yes \
   sedlex \
   utop \
   && opam_install_dependencies_succeeded=1
-test $opam_install_dependencies_succeeded = 1 \
+test "$opam_install_dependencies_succeeded" = 1 \
   || die 'Could not install dependencies'
 
 # Build and install hack parallel.


### PR DESCRIPTION
`test $var = 1` when `$var` is empty prints an error

    ./scripts/setup.sh: line 110: test: =: unary operator expected

With the variable quoted, it works as expected. (Tested on MacOS 10.12 bash v4.4)