### PR TITLE
[test] Fix assertion order for `assert_equal` statements

### DIFF
--- a/ast/test/astCodexTest.ml
+++ b/ast/test/astCodexTest.ml
@@ -10,7 +10,7 @@ open Test
 
 open Ast
 
-let assert_python_module_equal source expected =
+let assert_python_module_equal expected source =
   let actual = Codex.source_to_codex_representation "/tmp" (parse source) in
   assert_equal
     ~cmp:Codex.PythonModule.equal
@@ -62,7 +62,7 @@ let test_function _ =
         };
       }]
   in
-  assert_python_module_equal source expected_codex_representation
+  assert_python_module_equal expected_codex_representation source
 
 let test_variable _ =
   let source = "x = 1" in
@@ -76,7 +76,7 @@ let test_variable _ =
       };
     ]
   in
-  assert_python_module_equal source expected_codex_representation
+  assert_python_module_equal expected_codex_representation source
 
 
 let test_class _ =
@@ -119,7 +119,7 @@ let test_class _ =
           }];
       }];
   in
-  assert_python_module_equal source expected_codex_representation
+  assert_python_module_equal expected_codex_representation source
 
 
 let test_arguments _ =
@@ -151,7 +151,7 @@ let test_arguments _ =
       }
     ]
   in
-  assert_python_module_equal source expected_codex_representation
+  assert_python_module_equal expected_codex_representation source
 
 let test_source context =
   let directory = bracket_tmpdir context in
@@ -199,8 +199,8 @@ let test_source context =
   assert_equal
     ~cmp:Codex.PythonModule.equal
     ~printer:Codex.PythonModule.show
-    codex_representation
     expected_codex_representation
+    codex_representation
 
 
 let () =

--- a/ast/test/astStatementTest.ml
+++ b/ast/test/astStatementTest.ml
@@ -90,7 +90,7 @@ let test_is_constructor _ =
         parent;
       }
     in
-    assert_equal (Define.is_constructor ~in_test define) expected
+    assert_equal expected (Define.is_constructor ~in_test define)
   in
   assert_is_constructor ~name:"__init__" ~parent:(Some "foo") true;
   assert_is_constructor ~in_test:true ~name:"setUp" ~parent:(Some "foo") true;
@@ -695,7 +695,7 @@ let test_pp _ =
     in
 
     assert_equal ~pp_diff
-      pretty_print_of_source pretty_print_expected
+      pretty_print_expected pretty_print_of_source
   in
 
   (* Test 1 : simple def *)

--- a/ast/test/astVisitTest.ml
+++ b/ast/test/astVisitTest.ml
@@ -41,7 +41,7 @@ let test_collect _ =
         Sexp.pp (sexp_of_list Expression.sexp_of_t expressions)
         Sexp.pp (sexp_of_list Statement.sexp_of_t statements)
     in
-    assert_equal ~cmp:equal ~printer collect expected in
+    assert_equal ~cmp:equal ~printer expected collect in
 
   assert_collect
     [+Expression (+Float 1.0); +Expression (+Float 2.0)]
@@ -132,9 +132,9 @@ let test_collect_accesses_in_position _ =
     let position = { Location.line; column } in
     assert_equal
       ~printer:(String.concat ~sep:", ")
+      expected_accesses
       (List.map ~f:Node.value (Visit.collect_accesses_in_position source position)
        |> List.map ~f:Access.show)
-      expected_accesses
   in
   assert_collected_accesses source 2 0 ["s"];
   assert_collected_accesses source 2 4 ["ham.egg.(...).bake"];
@@ -204,7 +204,7 @@ let test_statement_visitor _ =
   let assert_counts source expected_counts =
     let table = Visit.visit (String.Table.create ()) source in
     List.iter
-      ~f:(fun (key, expected_value) -> assert_equal (Hashtbl.find table key) (Some expected_value))
+      ~f:(fun (key, expected_value) -> assert_equal (Some expected_value) (Hashtbl.find table key))
       expected_counts
   in
   let source = parse {|
@@ -240,10 +240,10 @@ let test_statement_visitor_source _ =
   in
   let module Visit = Visit.MakeStatementVisitor(StatementVisitor) in
   let path = Visit.visit "" (parse ~path:"test.py" "a = 1") in
-  assert_equal path "test.py";
+  assert_equal "test.py" path;
 
   let path = Visit.visit "" (parse ~path:"test2.py" "b = 2") in
-  assert_equal path "test2.py";
+  assert_equal "test2.py" path;
   ()
 
 let () =


### PR DESCRIPTION
The order for `assert_equals` is `expected` `real`. Fix the order for various expressions to help make the error messages more clear

Test Plan: `make test` still passes. Make a test fail and see the expected vs. actual message with the right values.

    diff --git a/ast/test/astCodexTest.ml b/ast/test/astCodexTest.ml
    index 26fd9ff..8aad206 100644
    --- a/ast/test/astCodexTest.ml
    +++ b/ast/test/astCodexTest.ml
    @@ -167,7 +167,7 @@ let test_source context =
         Codex.PythonModule.name = "test";
         docstring = None;
         rank = 0;
    -    filename = directory ^/ "test.py";
    +    filename = "test.py";
         members = [
           Codex.CodexNode.FunctionNode {
             Codex.CodexNode.Function.docstring = None;

Before:

    expected: { AstCodex.PythonModule.name = "test"; docstring = None; rank = 0;
      filename =
      "/private/var/folders/by/_z5tm9mj68lcn8jlnf6yl0500000gn/T/ounit-6b05e6-mzlee-air.local#00.dir/test.py";
      members = ...
      }
    but got: { AstCodex.PythonModule.name = "test"; docstring = None; rank = 0;
      filename = "test.py";
      members = ...
      }

After

    expected: { AstCodex.PythonModule.name = "test"; docstring = None; rank = 0;
      filename = "test.py";
      members = ...
      }
    but got: { AstCodex.PythonModule.name = "test"; docstring = None; rank = 0;
      filename = 
      "/private/var/folders/by/_z5tm9mj68lcn8jlnf6yl0500000gn/T/ounit-6b05e6-mzlee-air.local#00.dir/test.py";
      members = ...
      }
