### PR TITLE
Compatibility with Python 3.5 in filesystem_test.py

### DIFF
--- a/client/tests/filesystem_test.py
+++ b/client/tests/filesystem_test.py
@@ -226,4 +226,4 @@ class FilesystemTest(unittest.TestCase):
 
         shared_source_directory = SharedSourceDirectory(["first", "second"], True)
         shared_source_directory.cleanup()
-        rmtree.assert_called()
+        rmtree.assert_called_with(shared_source_directory.get_root())


### PR DESCRIPTION
mock.assert_called() was added in Python 3.6. Replace it with a more
specific call to assert_called_with().