### PR TITLE
Few line changes to make install slightly smoother

### DIFF
--- a/scripts/build-pypi-package.sh
+++ b/scripts/build-pypi-package.sh
@@ -33,6 +33,10 @@ trap error_trap ERR
 
 # Compatibility settings with MacOS.
 if [[ "${MACHTYPE}" = *apple* ]]; then
+  if ! [ -x "$(command -v greadlink)" ]; then
+    echo 'Error: greadlink is not installed. Please install coreutils.' >&2
+    exit 1
+  fi
   READLINK=greadlink
   HAS_PIP_GREATER_THAN_1_5=no
   WHEEL_DISTRIBUTION_PLATFORM=macosx_10_11_x86_64

--- a/scripts/generate-version-number.sh
+++ b/scripts/generate-version-number.sh
@@ -9,6 +9,10 @@ set -e
 
 # Compatibility settings with MacOS.
 if [[ "${MACHTYPE}" = *apple* ]]; then
+  if ! [ -x "$(command -v greadlink)" ]; then
+    echo 'Error: greadlink is not installed. Please install coreutils.' >&2
+    exit 1
+  fi
   READLINK=greadlink
 else
   READLINK=readlink

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,9 +16,22 @@ die() {
 DEVELOPMENT_COMPILER="4.06.0"
 RELEASE_COMPILER="4.06.0+flambda"
 
+version_less_than() {
+  if [ "$1" = "$2" ]; then
+    return 1
+  else
+    if ! [ -x "$(command -v gsort)" ]; then
+      die 'Error: gsort is not installed. Please install coreutils.'
+    fi
+    [ "$1" = "`echo -e "$1\n$2" | gsort -V | head -n1`" ]
+  fi
+}
+
 # Compatibility settings with MacOS.
 if [[ "${MACHTYPE}" = *apple* ]]; then
   export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -d '.' -f 1,2)"
+  version_less_than $MACOSX_DEPLOYMENT_TARGET 10.11 \
+    && die 'Error: The minimum OSX version supported is 10.11, please update.'
 fi
 
 # Switch to pyre directory.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ RELEASE_COMPILER="4.06.0+flambda"
 
 # Compatibility settings with MacOS.
 if [[ "${MACHTYPE}" = *apple* ]]; then
-  export MACOSX_DEPLOYMENT_TARGET=10.11
+  export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -d '.' -f 1,2)"
 fi
 
 # Switch to pyre directory.


### PR DESCRIPTION
Add 'install coreutils' message if greadlink not installed
Set MACOSX_DEPLOYMENT_TARGET based off sw_vers (only resulted in warnings, not errors.)

Let me know if instead or in addition to the `coreutils` check, you would like me to mention it and [`watchman`](https://facebook.github.io/watchman/docs/install.html#buildinstall) in the [Building from Source](https://pyre-check.org/docs/installation.html#building-from-source) instructions.

Side note: Looking forward to making **many** more PRs over the next few years 😉 Pyre seems awesome