### PR TITLE
Ignore Error Types

### DIFF
--- a/client/commands/reporting.py
+++ b/client/commands/reporting.py
@@ -22,6 +22,7 @@ class Reporting(Command):
         self._verbose = arguments.verbose
         self._output = arguments.output
         self._do_not_check_paths = configuration.do_not_check
+        self._ignore_error_types = configuration.ignore_error_types
         self._discovered_analysis_directories = [self._local_root]
         self._local_configuration = arguments.local_configuration
 
@@ -86,6 +87,9 @@ class Reporting(Command):
             relative_path = self._relative_path(full_path)
             error["path"] = relative_path
             do_not_check = False
+            # Make sure this error is not one to be ignored
+            if error["code"] in self._ignore_error_types:
+                do_not_check = True
             external_to_global_root = True
             if full_path.startswith(self._current_directory):
                 external_to_global_root = False

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ provides typed stubs for library functions.
 
 `workers`: Number of workers to spawn for multiprocessing.
 
+`ignore_error_types`: A list of error types to ignore from type-checking. The list of types can be found [here](https://pyre-check.org/docs/error-types.html)
 
 # Local Configuration
 If you have sub-projects within your project root that you would like to run Pyre on, you


### PR DESCRIPTION
This commit adds support for ignoring error types. One can ignore error types by error type code in the command line or in the configuration file.