### PR TITLE
make --search-path documentation more explicit

### DIFF
--- a/client/pyre.py
+++ b/client/pyre.py
@@ -144,8 +144,8 @@ def main() -> int:
         action="append",
         default=[],
         type=readable_directory,
-        help="Additional directories with modules and stubs "
-        "to include in type environment",
+        help="adds an additional directory of modules and stubs to include in type"
+        " environment each time it is passed",
     )
     parser.add_argument(
         "--preserve-pythonpath",


### PR DESCRIPTION
This change relates to #117. I am to make it more explicit that `--search-path` is passed multiple times, rather than a single time with a delimited list of directories (e.g. `path/to:your/pyton:modules/and/stubs`)