### PR TITLE
[RFC] Fix f-string analysis

### DIFF
--- a/analysis/test/preprocessingTest.ml
+++ b/analysis/test/preprocessingTest.ml
@@ -110,7 +110,7 @@ let test_expand_format_string _ =
   assert_format_string "f'{1}'" "{1}" [+Integer 1];
   assert_format_string "f'foo{1}'" "foo{1}" [+Integer 1];
   assert_format_string "f'foo{1}{2}foo'" "foo{1}{2}foo" [+Integer 1; +Integer 2];
-  assert_format_string "f'foo{{1}}'" "foo{{1}}" [+Integer 1];
+  assert_format_string "f'foo{{1}}'" "foo{{1}}" [];
   assert_format_string
     "f'foo{1+2}'"
     "foo{1+2}"

--- a/analysis/test/typeCheckTest.ml
+++ b/analysis/test/typeCheckTest.ml
@@ -7912,7 +7912,13 @@ let test_format_string _ =
         f'{boo() + "x"}'
     |}
     ["Incompatible parameter type [6]: " ^
-     "Expected `int` for 1st anonymous parameter to call `int.__add__` but got `str`."]
+     "Expected `int` for 1st anonymous parameter to call `int.__add__` but got `str`."];
+  assert_type_errors
+    {|
+       def foo() -> None:
+         f'{{{bad_global}}}'
+    |}
+    []
 
 
 let test_check_data_class _ =


### PR DESCRIPTION
Format strings allow escape sequences for curly braces, e.g. `f"{{x}}"` evaluates to the literal `"{x}"`. Fixes #97 .

NOTE: this is actually pretty bad - as you can see, it doesn't support nested expressions. `{{{x}}}` should be equivalent to `"{" + x + "}"`, but we're missing it altogether here.

I think the f-string analysis bit needs to be a state machine. I can do that, but in the meantime, RFC on conventions please!