### PR TITLE
Fixed f-string preprocessing

### DIFF
--- a/analysis/preprocessing.ml
+++ b/analysis/preprocessing.ml
@@ -147,29 +147,39 @@ let expand_format_string ({ Source.handle; _ } as source) =
       include Transform.Identity
       type t = unit
 
+      type state =
+        | Literal
+        | Expression of int * string
+
       let expression _ expression =
         match expression with
         | {
           Node.location = ({ Location.start = { Location.line; column }; _ } as location);
           value = String ({ StringLiteral.value; kind = StringLiteral.Format _; _ } as literal);
         } ->
-            let rec get_matches regular_expression input_string start_position =
-              try
-                let match_start_position =
-                  Str.search_forward regular_expression input_string start_position
+            let input_string_length = String.length value in
+            let rec expand_fstring input_string start_position state: ('a list) =
+              if start_position = input_string_length then
+                []
+              else
+                let token = String.get input_string start_position in
+                let expressions, next_state = match token, state with
+                  | '{', Literal -> [], Expression (start_position, "")
+                  | '{', Expression (_, "") -> [], Literal
+                  | '}', Literal -> [], Literal
+                  (* NOTE: this does not account for nested expressions in e.g. format specifiers. *)
+                  | '}', Expression (c, string) -> [(column + c, string)], Literal
+                  (* ignore leading whitespace in expressions *)
+                  | (' ' | '\t'), (Expression (_, "") as expression) -> [], expression
+                  | _, Literal -> [], Literal
+                  | _, Expression (c, string) -> [], Expression (c, string ^ (Char.to_string token))
                 in
-                let match_string = Str.matched_string input_string in
-                (match_start_position + column, match_string)
-                :: get_matches regular_expression input_string (match_start_position + 1)
-              with Not_found -> []
+                let next_expressions = expand_fstring input_string (start_position + 1) next_state in
+                expressions @ next_expressions
             in
             let parse (start_column, input_string) =
               try
-                let string =
-                  (String.length input_string) - 1
-                  |> String.slice input_string 1
-                  |> fun processed_input -> processed_input ^ "\n"
-                in
+                let string = input_string ^ "\n" in
                 match Parser.parse [string ^ "\n"] ~start_line:line ~start_column ~handle with
                 | [{ Node.value = Expression expression; _ }] -> [expression]
                 | _ -> failwith "Not an expression"
@@ -186,7 +196,7 @@ let expand_format_string ({ Source.handle; _ } as source) =
                   end
             in
             let expressions =
-              get_matches (Str.regexp "{[^{^}]*}") value 0
+              expand_fstring value 0 Literal
               |> List.concat_map ~f:parse
             in
             {

--- a/analysis/test/preprocessingTest.ml
+++ b/analysis/test/preprocessingTest.ml
@@ -110,7 +110,7 @@ let test_expand_format_string _ =
   assert_format_string "f'{1}'" "{1}" [+Integer 1];
   assert_format_string "f'foo{1}'" "foo{1}" [+Integer 1];
   assert_format_string "f'foo{1}{2}foo'" "foo{1}{2}foo" [+Integer 1; +Integer 2];
-  assert_format_string "f'foo{{1}}'" "foo{{1}}" [+Integer 1];
+  assert_format_string "f'foo{{1}}'" "foo{{1}}" [];
   assert_format_string
     "f'foo{1+2}'"
     "foo{1+2}"

--- a/analysis/test/typeCheckTest.ml
+++ b/analysis/test/typeCheckTest.ml
@@ -7912,7 +7912,19 @@ let test_format_string _ =
         f'{boo() + "x"}'
     |}
     ["Incompatible parameter type [6]: " ^
-     "Expected `int` for 1st anonymous parameter to call `int.__add__` but got `str`."]
+     "Expected `int` for 1st anonymous parameter to call `int.__add__` but got `str`."];
+  assert_type_errors
+    {|
+      def foo() -> None:
+        f'{{x}}'
+    |}
+    [];
+  assert_type_errors
+    {|
+      def foo() -> None:
+        f'{{{x}}}'
+    |}
+    ["Undefined name [18]: Global name `x` is undefined."]
 
 
 let test_check_data_class _ =


### PR DESCRIPTION
The sequence `{{` or `}}` in an f-string escapes the corresponding curly brace. The interior expression should not be interpreted as an expression. So, I converted the f-string parsing from a regex matcher to a state machine, which should also be more amenable to further improvements e.g. expressions for format specifiers like `{value:{width}.{precision}}`.

Fixes #97 .