### PR TITLE
[pyre] Skip integration test if watchman is missing for external builds

### DIFF
--- a/scripts/run_integration_test.py
+++ b/scripts/run_integration_test.py
@@ -221,6 +221,10 @@ class Repository:
 
 
 def run_integration_test(repository_path) -> int:
+    if not shutil.which("watchman"):
+        LOG.error("The integration test cannot work if watchman is not installed!")
+        return 1
+
     with tempfile.TemporaryDirectory() as base_directory:
         discrepancies = {}
         repository = Repository(base_directory, repository_path)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -192,4 +192,10 @@ jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
 make ${MAKE_ARGUMENTS} --jobs "$jobs" || die 'Could not build pyre'
 make --jobs "$jobs" test || die 'Pyre tests failed'
 make python_tests || die 'Python tests for Pyre failed'
-make server_integration_test || die 'Server integration test failed'
+if [[ "${BUILD}" == 'external' ]] && ! which watchman; then
+  echo 'Skipping integration test in external mode, since watchman is not installed'
+else
+  make server_integration_test || die 'Server integration test failed'
+fi
+
+exit 0


### PR DESCRIPTION
In case of external builds, watchman might not be installed: consider
the failure a benign one, and silently ignore the integration
test. Conversely, the test will always run if the build is set to
internal, or if watchman is installed (regardless of build type).