### PR TITLE
Fix python tests in hg-less environments

### DIFF
--- a/client/tests/upgrade_test.py
+++ b/client/tests/upgrade_test.py
@@ -163,17 +163,19 @@ class FixmeAllTest(unittest.TestCase):
         "gather_local_configurations",
         return_value=[upgrade.Configuration("local/.pyre_configuration.local", {})],
     )
+    @patch.object(upgrade.Configuration, "find_project_configuration", return_value=".")
     @patch.object(upgrade.Configuration, "remove_version")
     @patch.object(upgrade.Configuration, "get_errors")
     @patch("%s.run_fixme" % upgrade.__name__)
     def test_run_fixme_all(
-        self, run_fixme, get_errors, remove_version, gather, call
+        self, run_fixme, get_errors, remove_version, find_configuration, gather, call
     ) -> None:
         arguments = MagicMock()
         get_errors.return_value = []
         upgrade.run_fixme_all(arguments, [])
         run_fixme.assert_not_called()
         call.assert_not_called()
+
         errors = [
             {
                 "line": 2,
@@ -197,15 +199,17 @@ class FixmeAllTest(unittest.TestCase):
     @patch("subprocess.call")
     @patch.object(upgrade.Configuration, "remove_version")
     @patch.object(upgrade.Configuration, "get_errors")
+    @patch.object(upgrade.Configuration, "gather_local_configurations")
     @patch("%s.run_fixme" % upgrade.__name__)
     def test_upgrade_configuration(
-        self, run_fixme, get_errors, remove_version, call
+        self, run_fixme, local_configurations, get_errors, remove_version, call
     ) -> None:
         arguments = MagicMock()
-        get_errors.return_value = []
+        local_configurations.return_value = []
         upgrade.run_fixme_all(arguments, [])
         run_fixme.assert_not_called()
         call.assert_not_called()
+
         errors = [
             {
                 "line": 2,


### PR DESCRIPTION
Failures would be like:

```
======================================================================
ERROR: test_upgrade_configuration (client.tests.upgrade_test.FixmeAllTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "client/filesystem.py", line 246, in list
    stderr=subprocess.DEVNULL,
  File "/usr/lib64/python3.6/subprocess.py", line 403, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib64/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib64/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'hg': 'hg'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.6/unittest/mock.py", line 1179, in patched
    return func(*args, **keywargs)
  File "client/tests/upgrade_test.py", line 206, in test_upgrade_configuration
    upgrade.run_fixme_all(arguments, [])
  File "client/upgrade.py", line 401, in run_fixme_all
    configurations = Configuration.gather_local_configurations(arguments)
  File "client/upgrade.py", line 69, in gather_local_configurations
    configuration_paths = get_filesystem().list(".", ".pyre_configuration.local")
  File "client/filesystem.py", line 252, in list
    raise EnvironmentException("hg executable not found.")
client.exceptions.EnvironmentException: hg executable not found.

======================================================================
FAIL: test_run_fixme_all (client.tests.upgrade_test.FixmeAllTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python3.6/unittest/mock.py", line 1179, in patched
    return func(*args, **keywargs)
  File "client/tests/upgrade_test.py", line 194, in test_run_fixme_all
    ["hg", "commit", "--message", "[typing] Update pyre version for local"]
  File "/usr/lib64/python3.6/unittest/mock.py", line 824, in assert_called_once_with
    raise AssertionError(msg)
AssertionError: Expected 'call' to be called once. Called 0 times.
```