### PR TITLE
del unused code

### DIFF
--- a/client/pyre.py
+++ b/client/pyre.py
@@ -12,7 +12,6 @@ import shutil
 import sys
 import time
 import traceback
-from typing import Type  # noqa
 
 from . import (
     EnvironmentException,


### PR DESCRIPTION
when I install pyre-check in my Mac Pro
* Mojave 10.14.3
* Python version is `3.5.0`
I tried to run `pyre check` in my python project and got some error as below
```
    from typing import Type  # noqa
ImportError: cannot import name 'Type'
...
```
It looks like the line `from typing import Type` is an import error and never used, so I just delete it and it works.  