### PR TITLE
Ensure travis runs sapp tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ jobs:
     - name: "Build and run tests"
       install: scripts/travis_install_build_dependencies.sh
       script: ./scripts/setup.sh --local
+    - name: "Build and run tests for sapp"
+      install: pip install -r sapp/requirements.txt
+      script: cd sapp && python3 setup.py test


### PR DESCRIPTION
Since SAPP is embedded in the pyre project, we want travis to run its tests as well.