### PR TITLE
Fix flags assert in test_profiling test of command_test.py

### DIFF
--- a/client/commands/tests/command_test.py
+++ b/client/commands/tests/command_test.py
@@ -151,5 +151,12 @@ class CommandTest(unittest.TestCase):
         command = commands.Command(arguments, configuration, analysis_directory)
         self.assertEqual(
             command._flags(),
-            ["-profiling-output", ".pyre/profiling.log", "-project-root", "."],
+            [
+                "-logging-sections",
+                "parser",
+                "-profiling-output",
+                ".pyre/profiling.log",
+                "-project-root",
+                ".",
+            ],
         )


### PR DESCRIPTION
#### Summary
We updated flags so parser errors were shown by default [1] and
accidentally merged in a `-profiling-output` option test [2] afterwards
that fails with the updated flags. This fixes that test.

[1] e375c54d58be23558c811d331c8105c25d9e499f
[2] 2f3ad14d3aed8e4a4f46663697f24dd20946b0ad


#### Output
`make python_tests` now passes, before this change it outputted:
```
======================================================================
FAIL: test_profiling (client.commands.tests.command_test.CommandTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kevin/pyre/pyre-check/client/commands/tests/command_test.py", line 154, in test_profiling
    ["-profiling-output", ".pyre/profiling.log", "-project-root", "."],
AssertionError: Lists differ: ['-logging-sections', 'parser', '-profiling-[48 chars] '.'] != ['-profiling-output', '.pyre/profiling.log',[17 chars] '.']

First differing element 0:
'-logging-sections'
'-profiling-output'

First list contains 2 additional elements.
First extra element 4:
'-project-root'

+ ['-profiling-output', '.pyre/profiling.log', '-project-root', '.']
- ['-logging-sections',
-  'parser',
-  '-profiling-output',
-  '.pyre/profiling.log',
-  '-project-root',
-  '.']

----------------------------------------------------------------------
Ran 92 tests in 1.010s

FAILED (failures=1)
```



