### PR TITLE
Don't block for so long in persistent client

### DIFF
--- a/command/persistentCommand.ml
+++ b/command/persistentCommand.ml
@@ -10,8 +10,6 @@ open Pyre
 open Network
 open Server
 
-module Time = Core_kernel.Time_ns.Span
-
 
 type reason = string
 type exit_code = int
@@ -53,7 +51,7 @@ let communicate server_socket =
         ~read:[server_socket; Unix.stdin]
         ~write:[]
         ~except:[]
-        ~timeout:(`After (Time.of_sec 1.0))
+        ~timeout:`Immediately
         ()
       |> fun { Unix.Select_fds.read; _ } -> read
     in


### PR DESCRIPTION
Select here blocks for up to 1 second. This can lead to behavior where sending two LSP messages in quick succession appear to get buffered, but only one message is read/processed at a time (until, e.g., more input becomes available). Clients calling persistent may wait for the requests to be fulfilled (and therefore wait forever) if not all the input received is processed by persistent.

This change lets the persistent process immediately on available input. No easy way to test this with OUnit, so I'm punting :(