### PR TITLE
Add sqlite3 lib ccflag for hack_parallel.heap

### DIFF
--- a/hack_parallel/hack_parallel/heap/dune
+++ b/hack_parallel/hack_parallel/heap/dune
@@ -8,6 +8,7 @@
     hh_shared
     hh_shared_sqlite)
   (c_flags (:standard -I%{project_root}/hack_parallel/hack_parallel/third-party/lz4))
+  (c_library_flags (-lsqlite3))
   (libraries
     hack_parallel.collections
     hack_parallel.lz4


### PR DESCRIPTION
The hack_parallel.heap library relies on sqlite3 functions, so `make` at the project root fails without this. Logs [here](https://pastebin.com/YSdTM07H).

Also, Q: where else should the project's C deps be listed?