### PR TITLE
Wrap config paths in os.path.expanduser

### DIFF
--- a/client/configuration.py
+++ b/client/configuration.py
@@ -354,11 +354,16 @@ class Configuration:
                 configuration_directory = os.path.dirname(path)
                 if configuration_directory:
                     self.source_directories = [
+                        # TODO: Does it make sense to expanduser
+                        # when a configuration directory is present?
                         os.path.join(configuration_directory, os.path.expanduser(directory))
                         for directory in source_directories
                     ]
                 else:
-                    self.source_directories = source_directories
+                    self.source_directories = [
+                        os.path.expanduser(directory)
+                        for directory in source_directories
+                    ]
 
                 self.targets = configuration.consume(
                     "targets", default=[], current=self.targets, print_on_success=True

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -39,7 +39,7 @@ class SearchPathElement:
                     "Search path elements must have `root` and `subdirectory` specified."
                 )
             self.root = os.path.abspath(os.path.expanduser(element["root"]))
-            self.subdirectory = os.path.expanduser(element["subdirectory"])
+            self.subdirectory = element["subdirectory"]
 
     def path(self) -> str:
         subdirectory = self.subdirectory

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -31,15 +31,15 @@ class InvalidConfiguration(Exception):
 class SearchPathElement:
     def __init__(self, element: Union[Dict[str, str], str]) -> None:
         if isinstance(element, str):
-            self.root = os.path.abspath(element)
+            self.root = os.path.abspath(os.path.expanduser(element))
             self.subdirectory = None
         else:
             if "root" not in element or "subdirectory" not in element:
                 raise InvalidConfiguration(
                     "Search path elements must have `root` and `subdirectory` specified."
                 )
-            self.root = os.path.abspath(element["root"])
-            self.subdirectory = element["subdirectory"]
+            self.root = os.path.abspath(os.path.expanduser(element["root"]))
+            self.subdirectory = os.path.expanduser(element["subdirectory"])
 
     def path(self) -> str:
         subdirectory = self.subdirectory
@@ -354,7 +354,7 @@ class Configuration:
                 configuration_directory = os.path.dirname(path)
                 if configuration_directory:
                     self.source_directories = [
-                        os.path.join(configuration_directory, directory)
+                        os.path.join(configuration_directory, os.path.expanduser(directory))
                         for directory in source_directories
                     ]
                 else:
@@ -396,7 +396,7 @@ class Configuration:
 
                 binary = configuration.consume("binary", current=self._binary)
                 assert binary is None or isinstance(binary, str)
-                self._binary = binary
+                self._binary = os.path.expanduser(binary)
 
                 additional_search_path = configuration.consume(
                     "search_path", default=[]
@@ -420,7 +420,7 @@ class Configuration:
 
                 typeshed = configuration.consume("typeshed", current=self._typeshed)
                 assert typeshed is None or isinstance(typeshed, str)
-                self._typeshed = typeshed
+                self._typeshed = os.path.expanduser(typeshed)
 
                 taint_models_path = configuration.consume(
                     "taint_models_path", current=self.taint_models_path

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -399,7 +399,7 @@ class Configuration:
 
                 binary = configuration.consume("binary", current=self._binary)
                 assert binary is None or isinstance(binary, str)
-                if isinstance(binary, str):
+                if binary is not None:
                     binary = os.path.expanduser(binary)
                 self._binary = binary
 
@@ -425,7 +425,7 @@ class Configuration:
 
                 typeshed = configuration.consume("typeshed", current=self._typeshed)
                 assert typeshed is None or isinstance(typeshed, str)
-                if isinstance(typeshed, str):
+                if typeshed is not None:
                     typeshed = os.path.expanduser(typeshed)
                 self._typeshed = typeshed
 

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -396,7 +396,9 @@ class Configuration:
 
                 binary = configuration.consume("binary", current=self._binary)
                 assert binary is None or isinstance(binary, str)
-                self._binary = os.path.expanduser(binary)
+                if isinstance(binary, str):
+                    binary = os.path.expanduser(binary)
+                self._binary = binary
 
                 additional_search_path = configuration.consume(
                     "search_path", default=[]
@@ -420,7 +422,9 @@ class Configuration:
 
                 typeshed = configuration.consume("typeshed", current=self._typeshed)
                 assert typeshed is None or isinstance(typeshed, str)
-                self._typeshed = os.path.expanduser(typeshed)
+                if isinstance(typeshed, str):
+                    typeshed = os.path.expanduser(typeshed)
+                self._typeshed = typeshed
 
                 taint_models_path = configuration.consume(
                     "taint_models_path", current=self.taint_models_path

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -20,7 +20,6 @@ from . import (
 )
 from .exceptions import EnvironmentException
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -354,9 +354,7 @@ class Configuration:
                 configuration_directory = os.path.dirname(path)
                 if configuration_directory:
                     self.source_directories = [
-                        # TODO: Does it make sense to expanduser
-                        # when a configuration directory is present?
-                        os.path.join(configuration_directory, os.path.expanduser(directory))
+                        os.path.join(configuration_directory, directory)
                         for directory in source_directories
                     ]
                 else:

--- a/client/tests/configuration_test.py
+++ b/client/tests/configuration_test.py
@@ -24,6 +24,7 @@ class ConfigurationTest(unittest.TestCase):
     @patch("os.path.abspath", side_effect=lambda path: path)
     @patch("os.path.isdir", return_value=True)
     @patch("os.path.exists")
+    @patch("os.path.expanduser")
     @patch("os.access", return_value=True)
     @patch("builtins.open")
     @patch("hashlib.sha1")
@@ -38,6 +39,7 @@ class ConfigurationTest(unittest.TestCase):
         sha1,
         builtins_open,
         access,
+        expanduser,
         exists,
         isdir,
         _abspath,
@@ -53,6 +55,9 @@ class ConfigurationTest(unittest.TestCase):
                 "ignore_all_errors": ["buck-out/dev/gen"],
             },
             {},
+        ]
+        expanduser.side_effect = [
+            "a"
         ]
         configuration = Configuration()
         self.assertEqual(configuration.source_directories, ["a"])
@@ -180,6 +185,21 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(configuration.typeshed, "TYPE/VERSION/SHED/")
         self.assertEqual(configuration.search_path, ["simple_string/"])
         self.assertEqual(configuration.file_hash, "HASH")
+
+        expanduser.side_effect = [
+            "/home/user/simple_string_searchpath",
+            "/home/user/simple_string_searchpath"
+        ]
+        json_load.side_effect = [
+            {
+                "search_path": "~/simple_string_searchpath",
+                "typeshed": "~/simple_string_typeshed",
+            },
+            {},
+        ]
+        configuration = Configuration()
+        self.assertEqual(configuration.search_path, "/home/user/simple_string_searchpath")
+        self.assertEqual(configuration.typeshed, "/home/user/simple_string_typeshed")
 
         # Test loading of additional directories in the search path
         # via environment $PYTHONPATH.

--- a/client/tests/configuration_test.py
+++ b/client/tests/configuration_test.py
@@ -200,20 +200,22 @@ class ConfigurationTest(unittest.TestCase):
 
         json_load.side_effect = [
             {
-                "search_path": "~/simple_string_searchpath",
-                "typeshed": "~/simple_string_typeshed",
+                "search_path": ["~/simple", {"root": "~/simple", "subdirectory": "subdir"}],
+                "typeshed": "~/typeshed",
             },
             {},
         ]
         expanduser.side_effect = [
-            "/home/user/simple_string_searchpath",
-            "/home/user/simple_string_typeshed",
+            "/home/user/simple",
+            "/home/user/simple",
+            "subdir",
+            "/home/user/typeshed",
         ]
         configuration = Configuration()
         self.assertEqual(
-            configuration.search_path, ["/home/user/simple_string_searchpath"]
+            configuration.search_path, ["/home/user/simple", "/home/user/simple$subdir"]
         )
-        self.assertEqual(configuration.typeshed, "/home/user/simple_string_typeshed")
+        self.assertEqual(configuration.typeshed, "/home/user/typeshed")
 
         # Test loading of additional directories in the search path
         # via environment $PYTHONPATH.

--- a/client/tests/configuration_test.py
+++ b/client/tests/configuration_test.py
@@ -24,7 +24,9 @@ class ConfigurationTest(unittest.TestCase):
     @patch("os.path.abspath", side_effect=lambda path: path)
     @patch("os.path.isdir", return_value=True)
     @patch("os.path.exists")
-    @patch("os.path.expanduser", side_effect=lambda path: path.replace("~", "/home/user"))
+    @patch(
+        "os.path.expanduser", side_effect=lambda path: path.replace("~", "/home/user")
+    )
     @patch("os.access", return_value=True)
     @patch("builtins.open")
     @patch("hashlib.sha1")
@@ -185,10 +187,13 @@ class ConfigurationTest(unittest.TestCase):
 
         json_load.side_effect = [
             {
-                "search_path": ["~/simple", {"root": "~/simple", "subdirectory": "subdir"}],
+                "search_path": [
+                    "~/simple",
+                    {"root": "~/simple", "subdirectory": "subdir"},
+                ],
                 "typeshed": "~/typeshed",
                 "source_directories": ["a", "~/b"],
-                "binary": "~/bin"
+                "binary": "~/bin",
             },
             {},
         ]

--- a/client/tests/configuration_test.py
+++ b/client/tests/configuration_test.py
@@ -69,7 +69,7 @@ class ConfigurationTest(unittest.TestCase):
             {},
         ]
         configuration = Configuration("local/path")
-        self.assertEqual(configuration.source_directories, ["local/path"])
+        self.assertEqual(configuration.source_directories, ["local/path/a"])
 
         json_load.side_effect = [{"targets": ["//a/b/c"], "disabled": 1}, {}]
         configuration = Configuration()
@@ -187,6 +187,8 @@ class ConfigurationTest(unittest.TestCase):
             {
                 "search_path": ["~/simple", {"root": "~/simple", "subdirectory": "subdir"}],
                 "typeshed": "~/typeshed",
+                "source_directories": ["a", "~/b"],
+                "binary": "~/bin"
             },
             {},
         ]
@@ -195,6 +197,8 @@ class ConfigurationTest(unittest.TestCase):
             configuration.search_path, ["/home/user/simple", "/home/user/simple$subdir"]
         )
         self.assertEqual(configuration.typeshed, "/home/user/typeshed")
+        self.assertEqual(configuration.source_directories, ["a", "/home/user/b"])
+        self.assertEqual(configuration.binary, "/home/user/bin")
 
         # Test loading of additional directories in the search path
         # via environment $PYTHONPATH.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,10 @@ provides typed stubs for library functions.
 `extensions`: Consider extensions in this list equivalent to `.py` for type checking.
 Empty string indicates extensionless files.
 
+Configuration options declaring paths (`source_directories`, `binary`, `search_path`,
+and `typeshed`) will expand `~` into your user directory, i.e. `~/typeshed` is
+treated as `/home/username/typeshed`.
+
 
 # Local Configuration
 If you have sub-projects within your project root that you would like to run Pyre on, you


### PR DESCRIPTION
Intended to fix #165 

---

The idea was to cover every spot a path can be supplied via config file, though some of these places may not make much sense. For instance, I'm not familiar enough with Pyre to know if it does in both root and subdirectory of a `SearchPathElement` dictionary.

I haven't used pyre a ton yet, but I pretty quickly found a need for this in at least `typeshed`, `source_directories`, and `binary`. Open to any sorts of feedback on this!

---

This is opened as a draft because I would like to be open to feedback at any stage since I'm so new to Pyre, so as such there's still a little bit to do before this is ready for any final reviews/merging.

Still to-do:

- [x] Discuss whether it makes sense on each of these fields or anywhere else in Pyre
- [x] Patch `os.path.expanduser` where necessary to pass preexisting tests
- [x] Add new tests to each relevant field
- [x] Update documentation
- [x] Lint