### PR TITLE
Added sqlite3 dependency to opam file

### DIFF
--- a/hack_parallel.opam
+++ b/hack_parallel.opam
@@ -9,5 +9,6 @@ license: "MIT"
 build: ["dune" "build" "-p" name]
 depends: [
   "core"
+  "conf-sqlite3"
   "str"
 ]


### PR DESCRIPTION
Per @sinancepel's request on #156, added the virtual [`conf-sqlite3` dependency](https://opam.ocaml.org/packages/conf-sqlite3/) to `hack_parallel.opam`. This will require users to have the sqlite3 C library installed to install `hack_parallel`.

Tested by running `make clean all`.