### PR TITLE
Added documentation stubs for developing static analyses on pyre

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We value consistent code. Please follow the style of the surrounding code. Usefu
 * avoid abbreviations.
 * avoid variable indentations (e.g. lining up parameters with the opening parenthesis of a function). It tends to mess up the git blame and quickly results with conflicts with the line length limit.
 * add a trailing colon/semi-colon for multi-line lists and records, and have the closing bracket on the line after the semicolon.
-* prefer snake_case over camelCase for variables and function names, and prefer CamelCase over Snake_case for modules and classes.
+* prefer snake_case over camelCase for variables and function names, and prefer CamelCase over snake_case for modules and classes.
 
 ### Python
 <p>
@@ -67,17 +67,20 @@ On a high level, Pyre goes through the following steps to when "pyre" is called 
 
 2. Determine which pyre command to run. The commands include some which handle the lifetime and state of a persistent pyre server for a project, as well as a standalone run command called `pyre check`. The implementation of these commands are found under `commands/`. `main.ml` aggregates these commands, and handles the parsing of the command-line arguments. Most steps will eventually call the TypeCheckService.
 
-3. The TypeCheckService module will call the ParseService, which will locate all sources in the given source root and all dependencies, and parse, preprocess & add the sources into shared memory. ParseService and TypeCheckService both live under `service/`, whereas the parser itself is located in `parser/`, and the preprocessor is under `analysis/analysisPreprocessing.ml`. The AST (abstract syntax tree) that the source code is parsed into is specified in files under the `ast/` directory.
+3. The TypeCheckService module will call the ParseService, which will locate all sources in the given source root and all dependencies, and parse, preprocess & add the sources into shared memory. ParseService and TypeCheckService both live under `service/`, whereas the parser itself is located in `parser/`, and the preprocessor is under `analysis/preprocessing.ml`. The AST (abstract syntax tree) that the source code is parsed into is specified in files under the `ast/` directory.
 
 4. Next, pyre will populate the global type environment with the project's sources as well as that of the dependencies. Note that we don't recursively analyze the imports of the project's files, but instead add all sources to the environment at once. This choice makes it easier to parallelize the building of the type environment, but comes at the cost of not being able to depend on a file's dependencies being analyzed when adding it to the type environment. The type environment can be thought of as a collection of hash tables, mapping function, class, global, etc. names into their implementations that can be accessed from shared memory. The type order, which is explained in more detail in a section below, is also built here.
 
-The modules that do the heavy lifting here can be found under `analysis/analysisEnvironment.ml` and `analysis/analysisTypeOrder.ml`.
+The modules that do the heavy lifting here can be found under `analysis/environment.ml` and `analysis/typeOrder.ml`.
 
 5. Once the environment is built, pyre will start type checking all files under the source root in parallel. The key property here is that building the environment in the above step allows pyre to type check each function in parallel. The type checker will not go beyond function call boundaries, which is possible because we will have accumulated the parameter and return annotations of all functions before this step.
 
-During analysis, each function will be processed into a control flow graph to represent the flow of typing information (https://en.wikipedia.org/wiki/Control_flow_graph is a nice introduction to CFG's). The bird's eye view of the algorithm is that we initialize the analysis with the type information from the function's parameter, and follow the control flow of the function to annotate local variables that are encountered. When encountering an attribute access, call, etc., the propagated type information is checked against the already present signature, and an error is generated if the two aren't compatible. The `Abstract Interpretation` section provides a theoretical background for the analysis.
+During analysis, each function will be processed into a control flow graph to represent the flow of typing information (https://en.wikipedia.org/wiki/Control_flow_graph is a nice introduction to CFG's). The bird's eye view of the algorithm is that we initialize the analysis with the type information from the function's parameter, and follow the control flow of the function to annotate local variables that are encountered. When encountering an attribute access, call, etc., the propagated type information is checked against the already present signature, and an error is generated if the two aren't compatible. 
+
+We use abstract interpretation for our typechecking. The module type for our abstract domains is simply called `State`, and lives in `analysis/fixpoint.ml`. The intermediate representation of our types can be found in `analysis.type.ml`. For expected behavior, check `analysis/test/`. For information on how to extend the Pyre codebase with your own static analyses, look at `docs/developer.md`.
 
 6. TypeCheckService will collect all the errors and return them to the caller. In the case of `pyre check`, all errors will be reported to stdout.
+
 
 ## License
 By contributing to Pyre, you agree that your contributions will be licensed

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,36 @@
+---
+id: developer
+title: Developing on Pyre
+sidebar_label: Developing on Pyre
+---
+
+
+# Writing Your Own Static Analyses
+The architecture of Pyre makes it a suitable base for developers interested in writing their own static analysis tools for Python. In the next two subsections, we will talk about how to extend Pyre with two kinds of static analysis tools:
+1. those orthogonal to the typechecker
+2. those which strengthen our existing typechecker
+
+We will present an example of each to describe the process of developing such tools.
+
+
+## Extensions to The Typechecker: Numpy ndarrays
+Consider a static analysis which checks the validity of tensor operations using [numpy n-dimensional arrays](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html). A simple example is given below.
+```python
+from numpy import array
+
+a = array([1, 2, 3])
+b = array([1, 2])
+
+c = a + a   # valid
+d = a + 1   # valid due to broadcasting
+e = a + b   # invalid
+```
+
+### Getting the Type Information
+### Inferring List Length
+### Checking Validity of Tensor Operations
+### Tying Our Analysis to a Pyre Command
+
+
+## Orthogonal to The Typechecker: Taint Analysis
+**TODO**: Fill in documentation on how the taint analysis tool was built, with emphasis on how this approach can be generalized.


### PR DESCRIPTION
My friend and I are interested in typechecking tensor operations using numpy ndarrays. We're hoping to statically catch errors based on incorrect tensor shapes, for eg:

```python
a = array([1, 2])
b = array([1, 2, 3])
c = a + b    # invalid, shapes do not match
```

Pyre seems like a suitable codebase upon which we can write this tool. In doing so, we also plan to write general documentation to help those who wish to write static analysis tools on Pyre.