### PR TITLE
Unbreak sapp CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ jobs:
       install: scripts/travis_install_build_dependencies.sh
       script: ./scripts/setup.sh --local
     - name: "Build and run tests for sapp"
-      install: pip install -r tools/sapp/requirements.txt
       script: cd tools/sapp && python3 setup.py test


### PR DESCRIPTION
`requirements.txt` is removed in [this commit](https://github.com/facebook/pyre-check/commit/4288a9500753f016b0e36a9e69234d80841ec3aa)
The requirements are already automatically installed during setup. Therefore, we don't need to run `pip install -r requirements.txt`, and we can simply remove the line in CI config.