### PR TITLE
[docs/] Fix small typos

### DIFF
--- a/docs/pysa_basics.md
+++ b/docs/pysa_basics.md
@@ -130,7 +130,7 @@ sinks: [
 
 Stubs that indicate what is a sink are then defined in `.pysa` files. Sinks can
 be added to the same files as sources. Sinks are declared in the same places
-that [types are declared in python
+that [types are declared in Python
 3](https://docs.python.org/3/library/typing.html). Function parameters and even
 whole classes can be declared as sinks by adding `TaintSink[SINK_NAME]` where
 you would add a python type:
@@ -250,7 +250,7 @@ There are other stub files with the `.pyi` extension which can also exist in
 your codebase. These `.pyi` stubs are similar and use [the same
 syntax](https://www.python.org/dev/peps/pep-0484/#stub-files) as the `.pysa`
 stubs, but are not the stubs that are referred to in this document (though they
-are relavent to static analysis). See the "Stubs" section of the [Gradual Typing
+are relevent to static analysis). See the "Stubs" section of the [Gradual Typing
 page](gradual_typing.md) for more info.
 
 ### Requirements and Features
@@ -298,7 +298,7 @@ Pysa will complain if the signature of your stub doesn't exactly match the
 implementation. When working with functions defined outside your project, where
 you don't directly see the source. You can use [`pyre query`](querying_pyre.md)
 with the `signature` argument to have Pysa dump it's internal model of a
-function, so you know exactly how to write your model
+function, so you know exactly how to write your model.
 
 #### Eliding
 

--- a/docs/pysa_precollectors.md
+++ b/docs/pysa_precollectors.md
@@ -18,7 +18,7 @@ within the pyre-check repository.
 The majority of model generators require access to a running environment. For
 example, the `RESTApiSourceGenerator` needs to be able to access `urlpatterns`
 configured for Django, meaning it has to import (and implicitly run) the file
-you use to configure routing. The recommended way to run model generators to set
+you use to configure routing. The recommended way to run model generators is to set
 up a small script within your repository that can run within the virtual
 environment for your project. You can follow the pattern of
 `generate_taint_models.py` to construct a `ConfigurationArguments` object and
@@ -33,7 +33,7 @@ model generators which are currently provided out of the box with Pysa.
 
 This model generator is intended to taint all arguments to [Django view
 functions](https://docs.djangoproject.com/en/2.2/topics/http/views/) as
-`UserControlled`. This us useful when you have views that receive
+`UserControlled`. This is useful when you have views that receive
 user-controlled data as arguments separate from the `HttpRequest` parameter,
 such as when [capturing values from the request
 path](https://docs.djangoproject.com/en/2.2/topics/http/urls/#example).

--- a/docs/pysa_running.md
+++ b/docs/pysa_running.md
@@ -8,7 +8,7 @@ sidebar_label: Running Pysa
 
 The setup requires the following 4 types of files.
 
-1. **Source Code** (`*.py`): This is your application's code
+1. **Source Code** (`*.py`): This is your application's code.
 2. **Taint Config** (`taint.config`): This file declares sources, sinks,
    features, and rules.
 3. **Taint Stubs** (`.pysa`): These files link together the information in your


### PR DESCRIPTION
:mortar_board: [docs/] Fix typos

Great docs by the way! e.g. the [breadcrumbs](https://pyre-check.org/docs/pysa-features.html) are really cool. I avoided any changes I felt were opinionated, but happy to add those if requested.

FYI the [link here](https://pyre-check.org/docs/static-analysis-post-processor.html#example) leads to [a 404](https://pyre-check.org/docs/static-analysis.html#example), couldn't find which example page it was referencing.