### PR TITLE
Surface issue trace length

### DIFF
--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -1410,10 +1410,20 @@ details              show additional information about the current trace frame
                 f"            Code: {issue.code}",
                 f"         Message: {issue.message}",
                 f"        Callable: {issue.callable}",
-                f"         Sources: {sources_output if sources_output else 'No sources'}",
-                f"           Sinks: {sinks_output if sinks_output else 'No sinks'}",
-                f"        Location: {issue.filename}" f":{issue.location}",
-                f"Min Trace Length: Source ({issue.min_trace_length_to_sources}) | Sink ({issue.min_trace_length_to_sinks})",
+                (
+                    f"         Sources: "
+                    f"{sources_output if sources_output else 'No sources'}"
+                ),
+                (
+                    f"           Sinks: "
+                    f"{sinks_output if sinks_output else 'No sinks'}"
+                ),
+                (f"        Location: " f"{issue.filename}" f":{issue.location}"),
+                (
+                    f"Min Trace Length: "
+                    f"Source ({issue.min_trace_length_to_sources}) | "
+                    f"Sink ({issue.min_trace_length_to_sinks})"
+                ),
             ]
         )
 

--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -77,7 +77,8 @@ class IssueQueryResult(NamedTuple):
     code: int
     callable: str
     message: str
-
+    min_trace_length_to_sources: int
+    min_trace_length_to_sinks: int
 
 class TraceFrameQueryResult(NamedTuple):
     id: DBID
@@ -474,6 +475,8 @@ details              show additional information about the current trace frame
                     Issue.code,
                     CallableText.contents.label("callable"),
                     MessageText.contents.label("message"),
+                    IssueInstance.min_trace_length_to_sources,
+                    IssueInstance.min_trace_length_to_sinks,
                 )
                 .filter(IssueInstance.run_id == self.current_run_id)
                 .join(FilenameText, FilenameText.id == IssueInstance.filename_id)
@@ -1409,7 +1412,8 @@ details              show additional information about the current trace frame
                 f" Sources: {sources_output if sources_output else 'No sources'}",
                 f"   Sinks: {sinks_output if sinks_output else 'No sinks'}",
                 (f"Location: {issue.filename}" f":{issue.location}"),
-            ]
+                f"Min_trace_length_to_sources: {issue.min_trace_length_to_sources}",
+                f"Min_trace_length_to_sinks: {issue.min_trace_length_to_sinks}",            ]
         )
 
     def _create_trace_frame_output_string(
@@ -1504,6 +1508,8 @@ details              show additional information about the current trace frame
                 Issue.code,
                 CallableText.contents.label("callable"),
                 MessageText.contents.label("message"),
+                IssueInstance.min_trace_length_to_sources,
+                IssueInstance.min_trace_length_to_sinks,
             )
             .filter(IssueInstance.id == self.current_issue_instance_id)
             .join(Issue, IssueInstance.issue_id == Issue.id)

--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -1413,7 +1413,7 @@ details              show additional information about the current trace frame
                 f"         Sources: {sources_output if sources_output else 'No sources'}",
                 f"           Sinks: {sinks_output if sinks_output else 'No sinks'}",
                 f"        Location: {issue.filename}" f":{issue.location}",
-                f"Min Trace Length: Sink ({issue.min_trace_length_to_sources}) | Source ({issue.min_trace_length_to_sinks})",
+                f"Min Trace Length: Source ({issue.min_trace_length_to_sources}) | Sink ({issue.min_trace_length_to_sinks})",
             ]
         )
 

--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -80,6 +80,7 @@ class IssueQueryResult(NamedTuple):
     min_trace_length_to_sources: int
     min_trace_length_to_sinks: int
 
+
 class TraceFrameQueryResult(NamedTuple):
     id: DBID
     caller: str
@@ -1406,14 +1407,14 @@ details              show additional information about the current trace frame
         return "\n".join(
             [
                 f"Issue {issue.id}",
-                f"    Code: {issue.code}",
-                f" Message: {issue.message}",
-                f"Callable: {issue.callable}",
-                f" Sources: {sources_output if sources_output else 'No sources'}",
-                f"   Sinks: {sinks_output if sinks_output else 'No sinks'}",
-                (f"Location: {issue.filename}" f":{issue.location}"),
-                f"Min_trace_length_to_sources: {issue.min_trace_length_to_sources}",
-                f"Min_trace_length_to_sinks: {issue.min_trace_length_to_sinks}",            ]
+                f"            Code: {issue.code}",
+                f"         Message: {issue.message}",
+                f"        Callable: {issue.callable}",
+                f"         Sources: {sources_output if sources_output else 'No sources'}",
+                f"           Sinks: {sinks_output if sinks_output else 'No sinks'}",
+                f"        Location: {issue.filename}" f":{issue.location}",
+                f"Min Trace Length: Sink ({issue.min_trace_length_to_sources}) | Source ({issue.min_trace_length_to_sinks})",
+            ]
         )
 
     def _create_trace_frame_output_string(

--- a/tools/sapp/sapp/tests/interactive_test.py
+++ b/tools/sapp/sapp/tests/interactive_test.py
@@ -1615,6 +1615,37 @@ class InteractiveTest(TestCase):
         self.assertIn("Sources: source1", result)
         self.assertIn("Sinks: No sinks", result)
 
+    def testCreateIssueOutputStringTraceLength(self):
+        issue1 = IssueQueryResult(
+            id=1,
+            filename="module.py",
+            location=SourceLocation(1, 2, 3),
+            code=1000,
+            callable="module.function1",
+            message="root",
+            min_trace_length_to_sources=0,
+            min_trace_length_to_sinks=6,
+        )
+        sources = []
+        sinks = ["sink1", "sink2"]
+        result = self.interactive._create_issue_output_string(issue1, sources, sinks)
+        self.assertIn("Min Trace Length: Source (0) | Sink (6)", result)
+
+        issue2 = IssueQueryResult(
+            id=1,
+            filename="module.py",
+            location=SourceLocation(1, 2, 3),
+            code=1000,
+            callable="module.function1",
+            message="root",
+            min_trace_length_to_sources=3,
+            min_trace_length_to_sinks=1,
+        )
+        sources = []
+        sinks = ["sink1", "sink2"]
+        result = self.interactive._create_issue_output_string(issue2, sources, sinks)
+        self.assertIn("Min Trace Length: Source (3) | Sink (1)", result)
+
     def testListSourceCode(self):
         mock_data = """if this_is_true:
     print("This was true")

--- a/tools/sapp/sapp/tests/interactive_test.py
+++ b/tools/sapp/sapp/tests/interactive_test.py
@@ -1600,6 +1600,8 @@ class InteractiveTest(TestCase):
             code=1000,
             callable="module.function1",
             message="root",
+            min_trace_length_to_sources=1,
+            min_trace_length_to_sinks=1,
         )
         sources = []
         sinks = ["sink1", "sink2"]


### PR DESCRIPTION
This PR update Static Analysis Post Processor (SAPP) to surface the `min_trace_length_to_sources` and `min_trace_length_to_sinks` to the issue information page when calling `issues()` command. These information help the user to get more info about the trace length when doing analysis. 

Before:
```
>>> issues                                                                                                                                                                                    
Issue 1
    Code: 5001
 Message: Possible shell injection Data from [UserSpecified] source(s) may reach [RemoteCodeExecution] sink(s)
Callable: source.convert
 Sources: UserSpecified
   Sinks: RemoteCodeExecution
Location: source.py:9|22|32
```

After:
```
>>> issues                                                                                                                                                                                    
Issue 1
    Code: 5001
 Message: Possible shell injection Data from [UserSpecified] source(s) may reach [RemoteCodeExecution] sink(s)
Callable: source.convert
 Sources: UserSpecified
   Sinks: RemoteCodeExecution
Location: source.py:9|22|32
Min_trace_length_to_sources: 0
Min_trace_length_to_sinks: 1
```

This is the first part of series of update that would help user to get more info and have better queries to the static analysis result. We will add the ability to query issues with max `min_trace_length_to_sources` and `min_trace_length_to_sinks` on the next PR once this one is merged.