### PR TITLE
Query min trace length - SAPP Update

### DIFF
--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -445,10 +445,10 @@ details              show additional information about the current trace frame
         codes: Optional[Union[int, List[int]]] = None,
         callables: Optional[Union[str, List[str]]] = None,
         filenames: Optional[Union[str, List[str]]] = None,
-        minTraceLength_to_sources: Optional[Union[int, List[int]]] = None,
-        minTraceLength_to_sinks: Optional[Union[int, List[int]]] = None,
-        minTraceLength_max_to_sources: Optional[int] = None,
-        minTraceLength_max_to_sinks: Optional[int] = None,
+        exact_trace_length_to_sources: Optional[Union[int, List[int]]] = None,
+        exact_trace_length_to_sinks: Optional[Union[int, List[int]]] = None,
+        max_trace_length_to_sources: Optional[int] = None,
+        max_trace_length_to_sinks: Optional[int] = None,
     ):
         """Lists issues for the selected run.
 
@@ -457,13 +457,13 @@ details              show additional information about the current trace frame
             codes: int or list[int]        issue codes to filter on
             callables: str or list[str]    callables to filter on (supports wildcards)
             filenames: str or list[str]    filenames to filter on (supports wildcards)
-            minTraceLength_to_sources: 
+            exact_trace_length_to_sources: 
                 int or list[int]    min trace length to sources to filter on 
-            minTraceLength_to_sinks: 
+            exact_trace_length_to_sinks: 
                 int or list[int]    min trace length to sinks to filter on 
-            minTraceLength_max_to_sources: 
+            max_trace_length_to_sources: 
                 int    maximum min trace length to sources to filter on 
-            minTraceLength_max_to_sinks: 
+            max_trace_length_to_sinks: 
                 int    maximum min trace length to sinks to filter on 
 
         String filters support LIKE wildcards (%, _) from SQL:
@@ -512,56 +512,56 @@ details              show additional information about the current trace frame
                     filenames, query, FilenameText.contents, "filenames"
                 )
 
-            if (minTraceLength_to_sources is not None) and (
-                minTraceLength_max_to_sources is not None
+            if (exact_trace_length_to_sources is not None) and (
+                max_trace_length_to_sources is not None
             ):
                 raise UserError(
                     (
-                        f"'minTraceLength_to_sources' and "
-                        f"'minTraceLength_max_to_sources' can't be set together"
+                        f"'exact_trace_length_to_sources' and "
+                        f"'max_trace_length_to_sources' can't be set together"
                     )
                 )
 
-            if (minTraceLength_to_sinks is not None) and (
-                minTraceLength_max_to_sinks is not None
+            if (exact_trace_length_to_sinks is not None) and (
+                max_trace_length_to_sinks is not None
             ):
                 raise UserError(
                     (
-                        f"'minTraceLength_to_sinks' and "
-                        f"'minTraceLength_max_to_sinks' can't be set together"
+                        f"'exact_trace_length_to_sinks' and "
+                        f"'max_trace_length_to_sinks' can't be set together"
                     )
                 )
 
-            if minTraceLength_to_sources is not None:
+            if exact_trace_length_to_sources is not None:
                 query = self._add_list_or_int_filter_to_query(
-                    minTraceLength_to_sources,
+                    exact_trace_length_to_sources,
                     query,
                     IssueInstance.min_trace_length_to_sources,
-                    "minTraceLength_to_sources",
+                    "exact_trace_length_to_sources",
                 )
 
-            if minTraceLength_to_sinks is not None:
+            if exact_trace_length_to_sinks is not None:
                 query = self._add_list_or_int_filter_to_query(
-                    minTraceLength_to_sinks,
+                    exact_trace_length_to_sinks,
                     query,
                     IssueInstance.min_trace_length_to_sinks,
-                    "minTraceLength_to_sinks",
+                    "exact_trace_length_to_sinks",
                 )
 
-            if minTraceLength_max_to_sources is not None:
+            if max_trace_length_to_sources is not None:
                 query = self._add_max_int_filter_to_query(
-                    minTraceLength_max_to_sources,
+                    max_trace_length_to_sources,
                     query,
                     IssueInstance.min_trace_length_to_sources,
-                    "minTraceLength_max_to_sources",
+                    "max_trace_length_to_sources",
                 )
 
-            if minTraceLength_max_to_sinks is not None:
+            if max_trace_length_to_sinks is not None:
                 query = self._add_max_int_filter_to_query(
-                    minTraceLength_max_to_sinks,
+                    max_trace_length_to_sinks,
                     query,
                     IssueInstance.min_trace_length_to_sinks,
-                    "minTraceLength_max_to_sinks",
+                    "max_trace_length_to_sinks",
                 )
 
             issues = query.join(Issue, IssueInstance.issue_id == Issue.id).join(

--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -457,14 +457,14 @@ details              show additional information about the current trace frame
             codes: int or list[int]        issue codes to filter on
             callables: str or list[str]    callables to filter on (supports wildcards)
             filenames: str or list[str]    filenames to filter on (supports wildcards)
-            exact_trace_length_to_sources: 
-                int or list[int]    min trace length to sources to filter on 
-            exact_trace_length_to_sinks: 
-                int or list[int]    min trace length to sinks to filter on 
-            max_trace_length_to_sources: 
-                int    maximum min trace length to sources to filter on 
-            max_trace_length_to_sinks: 
-                int    maximum min trace length to sinks to filter on 
+            exact_trace_length_to_sources: int or list[int]
+                exact values for min trace length to sources to filter on
+            exact_trace_length_to_sinks: int or list[int]
+                exact values for min trace length to sinks to filter on
+            max_trace_length_to_sources: int
+                maximum value for min trace length to sources to filter on
+            max_trace_length_to_sinks: int
+                maximum value for min trace length to sinks to filter on
 
         String filters support LIKE wildcards (%, _) from SQL:
             % matches anything (like .* in regex)

--- a/tools/sapp/sapp/tests/fake_object_generator.py
+++ b/tools/sapp/sapp/tests/fake_object_generator.py
@@ -185,6 +185,8 @@ class FakeObjectGenerator:
         filename="/r/some/filename.py",
         callable="Foo.barMethod",
         issue_id=None,
+        min_trace_length_to_sources=None,
+        min_trace_length_to_sinks=None,
     ):
         issue_id = issue_id if issue_id is not None else DBID(1)
         filename = self.filename(filename)
@@ -198,6 +200,8 @@ class FakeObjectGenerator:
             callable_id=callable.id,
             run_id=self.run_id,
             issue_id=issue_id,
+            min_trace_length_to_sources=min_trace_length_to_sources,
+            min_trace_length_to_sinks=min_trace_length_to_sinks,
         )
         if self.graph:
             self.graph.add_issue_instance(result)

--- a/tools/sapp/sapp/tests/interactive_test.py
+++ b/tools/sapp/sapp/tests/interactive_test.py
@@ -262,90 +262,90 @@ class InteractiveTest(TestCase):
 
         self.interactive.setup()
 
-        self.interactive.issues(minTraceLength_to_sources="1")
+        self.interactive.issues(exact_trace_length_to_sources="1")
         stderr = self.stderr.getvalue().strip()
-        self.assertIn("'minTraceLength_to_sources' should be", stderr)
+        self.assertIn("'exact_trace_length_to_sources' should be", stderr)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_to_sinks="1")
+        self.interactive.issues(exact_trace_length_to_sinks="1")
         stderr = self.stderr.getvalue().strip()
-        self.assertIn("'minTraceLength_to_sinks' should be", stderr)
+        self.assertIn("'exact_trace_length_to_sinks' should be", stderr)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_max_to_sources="1")
+        self.interactive.issues(max_trace_length_to_sources="1")
         stderr = self.stderr.getvalue().strip()
-        self.assertIn("'minTraceLength_max_to_sources' should be", stderr)
+        self.assertIn("'max_trace_length_to_sources' should be", stderr)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_max_to_sinks="1")
+        self.interactive.issues(max_trace_length_to_sinks="1")
         stderr = self.stderr.getvalue().strip()
-        self.assertIn("'minTraceLength_max_to_sinks' should be", stderr)
+        self.assertIn("'max_trace_length_to_sinks' should be", stderr)
         self._clear_stdout()
 
         self.interactive.issues(
-            minTraceLength_to_sources=1, minTraceLength_max_to_sources=1
+            exact_trace_length_to_sources=1, max_trace_length_to_sources=1
         )
         stderr = self.stderr.getvalue().strip()
         self.assertIn("can't be set together", stderr)
         self._clear_stdout()
 
         self.interactive.issues(
-            minTraceLength_to_sinks=1, minTraceLength_max_to_sinks=1
+            exact_trace_length_to_sinks=1, max_trace_length_to_sinks=1
         )
         stderr = self.stderr.getvalue().strip()
         self.assertIn("can't be set together", stderr)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_to_sources=1)
+        self.interactive.issues(exact_trace_length_to_sources=1)
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertNotIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_to_sinks=1)
+        self.interactive.issues(exact_trace_length_to_sinks=1)
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertNotIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_to_sources=[1, 2])
+        self.interactive.issues(exact_trace_length_to_sources=[1, 2])
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_to_sinks=[1, 2])
+        self.interactive.issues(exact_trace_length_to_sinks=[1, 2])
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_max_to_sources=1)
+        self.interactive.issues(max_trace_length_to_sources=1)
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertNotIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_max_to_sinks=1)
+        self.interactive.issues(max_trace_length_to_sinks=1)
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertNotIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_max_to_sources=2)
+        self.interactive.issues(max_trace_length_to_sources=2)
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertIn("Issue 2", output)
         self.assertNotIn("Issue 3", output)
         self._clear_stdout()
 
-        self.interactive.issues(minTraceLength_max_to_sinks=2)
+        self.interactive.issues(max_trace_length_to_sinks=2)
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
         self.assertIn("Issue 2", output)
@@ -353,7 +353,7 @@ class InteractiveTest(TestCase):
         self._clear_stdout()
 
         self.interactive.issues(
-            minTraceLength_max_to_sources=1, minTraceLength_max_to_sinks=1,
+            max_trace_length_to_sources=1, max_trace_length_to_sinks=1,
         )
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
@@ -362,7 +362,7 @@ class InteractiveTest(TestCase):
         self._clear_stdout()
 
         self.interactive.issues(
-            minTraceLength_max_to_sources=1, minTraceLength_max_to_sinks=2,
+            max_trace_length_to_sources=1, max_trace_length_to_sinks=2,
         )
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)

--- a/tools/sapp/sapp/tests/interactive_test.py
+++ b/tools/sapp/sapp/tests/interactive_test.py
@@ -353,7 +353,7 @@ class InteractiveTest(TestCase):
         self._clear_stdout()
 
         self.interactive.issues(
-            max_trace_length_to_sources=1, max_trace_length_to_sinks=1,
+            max_trace_length_to_sources=1, max_trace_length_to_sinks=1
         )
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)
@@ -362,7 +362,7 @@ class InteractiveTest(TestCase):
         self._clear_stdout()
 
         self.interactive.issues(
-            max_trace_length_to_sources=1, max_trace_length_to_sinks=2,
+            max_trace_length_to_sources=1, max_trace_length_to_sinks=2
         )
         output = self.stdout.getvalue().strip()
         self.assertIn("Issue 1", output)

--- a/tools/sapp/sapp/tests/interactive_test.py
+++ b/tools/sapp/sapp/tests/interactive_test.py
@@ -165,6 +165,8 @@ class InteractiveTest(TestCase):
             issue_id=issue1.id,
             callable="module.sub.function1",
             filename="module/sub.py",
+            min_trace_length_to_sources=1,
+            min_trace_length_to_sinks=1,
         )
         self.fakes.save_all(self.db)
 
@@ -173,6 +175,8 @@ class InteractiveTest(TestCase):
             issue_id=issue2.id,
             callable="module.sub.function2",
             filename="module/sub.py",
+            min_trace_length_to_sources=2,
+            min_trace_length_to_sinks=2,
         )
         self.fakes.save_all(self.db)
 
@@ -181,6 +185,8 @@ class InteractiveTest(TestCase):
             issue_id=issue3.id,
             callable="module.function3",
             filename="module/__init__.py",
+            min_trace_length_to_sources=3,
+            min_trace_length_to_sinks=3,
         )
         self.fakes.save_all(self.db)
 
@@ -250,6 +256,119 @@ class InteractiveTest(TestCase):
         self.assertNotIn("Issue 1", output)
         self.assertNotIn("Issue 2", output)
         self.assertIn("Issue 3", output)
+
+    def testListIssuesFilterMinTraceLength(self):
+        self._list_issues_filter_setup()
+
+        self.interactive.setup()
+
+        self.interactive.issues(minTraceLength_to_sources="1")
+        stderr = self.stderr.getvalue().strip()
+        self.assertIn("'minTraceLength_to_sources' should be", stderr)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_to_sinks="1")
+        stderr = self.stderr.getvalue().strip()
+        self.assertIn("'minTraceLength_to_sinks' should be", stderr)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_max_to_sources="1")
+        stderr = self.stderr.getvalue().strip()
+        self.assertIn("'minTraceLength_max_to_sources' should be", stderr)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_max_to_sinks="1")
+        stderr = self.stderr.getvalue().strip()
+        self.assertIn("'minTraceLength_max_to_sinks' should be", stderr)
+        self._clear_stdout()
+
+        self.interactive.issues(
+            minTraceLength_to_sources=1, minTraceLength_max_to_sources=1
+        )
+        stderr = self.stderr.getvalue().strip()
+        self.assertIn("can't be set together", stderr)
+        self._clear_stdout()
+
+        self.interactive.issues(
+            minTraceLength_to_sinks=1, minTraceLength_max_to_sinks=1
+        )
+        stderr = self.stderr.getvalue().strip()
+        self.assertIn("can't be set together", stderr)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_to_sources=1)
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertNotIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_to_sinks=1)
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertNotIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_to_sources=[1, 2])
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_to_sinks=[1, 2])
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_max_to_sources=1)
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertNotIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_max_to_sinks=1)
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertNotIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_max_to_sources=2)
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(minTraceLength_max_to_sinks=2)
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(
+            minTraceLength_max_to_sources=1, minTraceLength_max_to_sinks=1,
+        )
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertNotIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
+
+        self.interactive.issues(
+            minTraceLength_max_to_sources=1, minTraceLength_max_to_sinks=2,
+        )
+        output = self.stdout.getvalue().strip()
+        self.assertIn("Issue 1", output)
+        self.assertNotIn("Issue 2", output)
+        self.assertNotIn("Issue 3", output)
+        self._clear_stdout()
 
     def testNoRunsFound(self):
         self.interactive.setup()


### PR DESCRIPTION
This PR update Static Analysis Post Processor (SAPP) to filter issues based on its `min_trace_length_to_sources` and `min_trace_length_to_sinks`. These capabilities help users to easily query and narrow down issues when doing the analysis.

Filter addition to issues command:
`minTraceLength_to_sources`: int or list[int]   -> min trace length to sources to filter on 
`minTraceLength_to_sinks`: int or list[int]   -> min trace length to sinks to filter on 
`minTraceLength_max_to_sources`: int  ->  maximum min trace length to sources to filter on 
`minTraceLength_max_to_sinks`: int   -> maximum min trace length to sinks to filter on 

Sample:
```
[ run 1 ]                                                                                                                                                                                                   
>>> issues(minTraceLength_to_sources=0)                                                                                                                                                                 
Issue 1
            Code: 5001
         Message: Possible shell injection Data from [UserSpecified] source(s) may reach [RemoteCodeExecution] sink(s)
        Callable: source.convert
         Sources: UserSpecified
           Sinks: RemoteCodeExecution
        Location: source.py:9|22|32
Min Trace Length: Source (0) | Sink (1)
Found 1 issues with run_id 1.

[ run 1 ]                                                                                                                                                                                                   
>>> issues(minTraceLength_max_to_sources=0,minTraceLength_max_to_sinks=0)                                                                                                                                   

Found 0 issues with run_id 1.
```