### PR TITLE
Sapp: show features/breadcrumbs

### DIFF
--- a/tools/sapp/sapp/interactive.py
+++ b/tools/sapp/sapp/interactive.py
@@ -201,8 +201,10 @@ details              show additional information about the current trace frame
 
         self.sources: Set[str] = set()
         self.sinks: Set[str] = set()
+        self.features: Set[str] = set()
         self.sources_dict: Dict[int, str] = {}
         self.sinks_dict: Dict[int, str] = {}
+        self.features_dict: Dict[int, str] = {}
 
         # Tuples representing the trace of the current issue
         self.trace_tuples: List[TraceTuple] = []
@@ -223,6 +225,9 @@ details              show additional information about the current trace frame
 
             self.sources_dict = self._all_leaves_by_kind(session, SharedTextKind.SOURCE)
             self.sinks_dict = self._all_leaves_by_kind(session, SharedTextKind.SINK)
+            self.features_dict = self._all_leaves_by_kind(
+                session, SharedTextKind.FEATURE
+            )
 
         print("=" * len(self.welcome_message))
         print(self.welcome_message)
@@ -409,6 +414,10 @@ details              show additional information about the current trace frame
                 session, issue_instance_id, SharedTextKind.SINK
             )
 
+            self.features = self._get_leaves_issue_instance(
+                session, issue_instance_id, SharedTextKind.FEATURE
+            )
+
         self.current_issue_instance_id = int(selected_issue.id)
         self.current_frame_id = -1
         self.current_trace_frame_index = 1  # first one after the source
@@ -580,10 +589,17 @@ details              show additional information about the current trace frame
                 )
                 for issue in issues
             ]
-
+            features_list = [
+                self._get_leaves_issue_instance(
+                    session, int(issue.id), SharedTextKind.FEATURE
+                )
+                for issue in issues
+            ]
             issue_strings = [
-                self._create_issue_output_string(issue, sources, sinks)
-                for issue, sources, sinks in zip(issues, sources_list, sinks_list)
+                self._create_issue_output_string(issue, sources, sinks, features)
+                for issue, sources, sinks, features in zip(
+                    issues, sources_list, sinks_list, features_list
+                )
             ]
         issue_output = f"\n{'-' * 80}\n".join(issue_strings)
         pager(issue_output)
@@ -1486,10 +1502,15 @@ details              show additional information about the current trace frame
         return filtered_results
 
     def _create_issue_output_string(
-        self, issue: IssueQueryResult, sources: Set[str], sinks: Set[str]
+        self,
+        issue: IssueQueryResult,
+        sources: Set[str],
+        sinks: Set[str],
+        features: Set[str],
     ) -> str:
-        sources_output = f"\n{' ' * 10}".join(sources)
-        sinks_output = f"\n{' ' * 10}".join(sinks)
+        sources_output = f"\n{' ' * 18}".join(sources)
+        sinks_output = f"\n{' ' * 18}".join(sinks)
+        features_output = f"\n{' ' * 18}".join(features)
         return "\n".join(
             [
                 f"Issue {issue.id}",
@@ -1503,6 +1524,10 @@ details              show additional information about the current trace frame
                 (
                     f"           Sinks: "
                     f"{sinks_output if sinks_output else 'No sinks'}"
+                ),
+                (
+                    f"        Features: "
+                    f"{features_output if features_output else 'No features'}"
                 ),
                 (f"        Location: " f"{issue.filename}" f":{issue.location}"),
                 (
@@ -1648,9 +1673,12 @@ details              show additional information about the current trace frame
     def _leaf_dict_lookups(
         self, message_ids: List[int], kind: SharedTextKind
     ) -> Set[str]:
-        leaf_dict = (
-            self.sources_dict if kind == SharedTextKind.SOURCE else self.sinks_dict
-        )
+        if kind == SharedTextKind.SOURCE:
+            leaf_dict = self.sources_dict
+        elif kind == SharedTextKind.SINK:
+            leaf_dict = self.sinks_dict
+        else:
+            leaf_dict = self.features_dict
         return {leaf_dict[id] for id in message_ids if id in leaf_dict}
 
     def _show_current_issue_instance(self):
@@ -1658,7 +1686,9 @@ details              show additional information about the current trace frame
             issue = self._get_current_issue(session)
 
         page.display_page(
-            self._create_issue_output_string(issue, self.sources, self.sinks)
+            self._create_issue_output_string(
+                issue, self.sources, self.sinks, self.features
+            )
         )
 
     def _show_current_trace_frame(self):


### PR DESCRIPTION
This PR update Static Analysis Post Processor (SAPP) to show issue's features/breadcrumbs. It will print the `Features:` of an issue when calling `issues/issue` command. These information is helpful for users when doing the analysis.

Sample:
```
>>> issues                                                                                                                  
Issue 2
            Code: 5001
         Message: Possible shell injection Data from [UserSpecified] source(s) may reach [RemoteCodeExecution] sink(s)
        Callable: source.convert
         Sources: UserSpecified
           Sinks: RemoteCodeExecution
        Features: always-via:input
                  always-via:obscure
        Location: source.py:9|22|32
Min Trace Length: Source (0) | Sink (1)
Found 1 issues with run_id 2.
```