### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -45,6 +45,10 @@ const siteConfig = {
     theme: 'default',
   },
   scripts: ['https://buttons.github.io/buttons.js'],
+  algolia: {
+    apiKey: '751912c73065099b3ff10de18c55b7df',
+    indexName: 'pyre-check',
+  },
   repoUrl: 'https://github.com/facebook/pyre-check',
 };
 


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.