### PR TITLE
Small Pysa tutorial and pysa_precollectors.md edits

### DIFF
--- a/docs/pysa_precollectors.md
+++ b/docs/pysa_precollectors.md
@@ -9,7 +9,7 @@ sidebar_label: Dynamically Generating Models
 Some sources and sinks may be too numerous or too rapidly changing for defining
 them statically to be practical. For these scenarios, Pysa has the concept of
 model generators, which can generate taint stubs by reading the project's source code before static analysis is
-started. The current set of model generators are stored in
+started. The current set of model generators is stored in
 [`tools/generate_taint_models`](https://github.com/facebook/pyre-check/tree/master/tools/generate_taint_models)
 within the pyre-check repository.
 

--- a/pysa_tutorial/exercise3/README.md
+++ b/pysa_tutorial/exercise3/README.md
@@ -2,11 +2,11 @@
 ## Overview
 The purpose of this exercise is to learn how to remove false positive issues using _sanitizers_.
 
-None of the functions in `views.py` are vulnerable, but they will all show up in `pyre analyze` as false positives. The goal of this exercise is the make changes to `sources_sinks.pysa` and `views.py` in order to remove the false positives.
+None of the functions in `views.py` are vulnerable, but they will all show up in `pyre analyze` as false positives. The goal of this exercise is to make changes to `sources_sinks.pysa` and `views.py` in order to remove the false positives.
 
 ## What you need to know
 ### Pre-written Taint Annotations
-Pysa comes with pre-written sources, sinks, and rules for much of the Python standard library, and many open source libraries. Since the previous exercises already covered those concepts, from this exercise forward we will be relying on pre-written sources, sinks, and rules where we can. You can look at collection of pre-written `taint.config` and `.pysa` files in the `stubs/taint` folder in this repository. If you're curious about what changed between this and the previous exercise to allow us to take advantage of those pre-written files, compare the `.pyre_configuration` files.
+Pysa comes with pre-written sources, sinks, and rules for much of the Python standard library, and many open source libraries. Since the previous exercises already covered those concepts, from this exercise forward we will be relying on pre-written sources, sinks, and rules where we can. You can look at the collection of pre-written `taint.config` and `.pysa` files in the `stubs/taint` folder in this repository. If you're curious about what changed between this and the previous exercise to allow us to take advantage of those pre-written files, compare the `.pyre_configuration` files.
 
 ### Sanitizers
 _Sanitizers_ are defined in `.pysa` files, just like sources and sinks. An example is provided in `sanitizers.pysa` and you'll have to add more of your own.

--- a/pysa_tutorial/exercise4/README.md
+++ b/pysa_tutorial/exercise4/README.md
@@ -14,11 +14,11 @@ Dynamic model generators run before Pysa, and generate `.pysa` files to identify
 
 1. `operate_on_twos` accepts a raw string in its interface, which is extracted from the request URL, according to the pattern specified in `urls.py`. This string is user-controlled, but Pysa doesn't know that. Update `generate_models.py` to correctly generate a `.pysa` file, which will tell Pysa that the `operator` argument to `operate_on_twos` is user-controlled. _Note that this `urls.py` + `views.py` pattern is designed to closely resemble how Django dispatches incoming requests._
 
-   1. Replace the TODO in `generate_models.py` with the name for the correct dynamic model generator to taint a Django-style API
+   1. Replace the TODO comment sections in `generate_models.py` with the correct dynamic model generator to taint a Django-style API
 
-   1. Run `python3 ./generate_models.py` from this directory
+   1. Run `python3 generate_models.py --output-directory .` from this directory
 
-   1. Verify that you have a `.pysa` file generated for you, and that the file correctly declares the `operator` argument to `operate_on_twos` as `UserControlled`
+   1. Verify that you have a `.pysa` file generated for you, and that the file correctly declares the `operator` argument to `operate_on_twos` as `TaintSource[UserControlled]`
 
    1. Run `pyre analyze`, and verify you see **1 issue** in the output.
 
@@ -28,8 +28,8 @@ Dynamic model generators run before Pysa, and generate `.pysa` files to identify
 
    1. Update `generate_models.py` to also call the generator you identified.
 
-   1. Run `python3 ./generate_models.py` from this directory
+   1. Run `python3 generate_models.py --output-directory .` from this directory
 
-   1. Verify that you have a new `.pysa` file generated, in addition to the one from the previous section. Check that this file is correctly declaring the `operator` argument to `operate_on_threes` as `UserControlled`
+   1. Verify that you have a new `.pysa` file generated, in addition to the one from the previous section. Check that this file is correctly declaring the `operator` argument to `operate_on_threes` as `TaintSource[UserControlled]`
 
    1. Run `pyre analyze`, and verify you see **2 issues** in the output.

--- a/pysa_tutorial/exercise4/README.md
+++ b/pysa_tutorial/exercise4/README.md
@@ -14,8 +14,6 @@ Dynamic model generators run before Pysa, and generate `.pysa` files to identify
 
 1. `operate_on_twos` accepts a raw string in its interface, which is extracted from the request URL, according to the pattern specified in `urls.py`. This string is user-controlled, but Pysa doesn't know that. Update `generate_models.py` to correctly generate a `.pysa` file, which will tell Pysa that the `operator` argument to `operate_on_twos` is user-controlled. _Note that this `urls.py` + `views.py` pattern is designed to closely resemble how Django dispatches incoming requests._
 
-   1. Replace the TODO comment sections in `generate_models.py` with the correct dynamic model generator to taint a Django-style API
-
    1. Run `python3 generate_models.py --output-directory .` from this directory
 
    1. Verify that you have a `.pysa` file generated for you, and that the file correctly declares the `operator` argument to `operate_on_twos` as `TaintSource[UserControlled]`

--- a/pysa_tutorial/exercise4/generate_models.py
+++ b/pysa_tutorial/exercise4/generate_models.py
@@ -26,20 +26,19 @@ class Ignore:
 def main() -> None:
     # Here, specify all the generators that you might want to call.
     generators = {
-        # TODO
-        # "replace_me": generate_taint_models.SomeGenerator(
-        #     ...
-        # ),
+        "get_REST_api_sources": generate_taint_models.RESTApiSourceGenerator(
+            django_urls=view_generator.DjangoUrls(
+                urls_module="urls",
+                url_pattern_type=UrlPattern,
+                url_resolver_type=Ignore,
+            )
+        )
     }
     # The `run_generators` function will take care of parsing command-line arguments, as
     # well as executing the generators specified in `default_modes` unless you pass in a
     # specific set from the command line.
     generate_taint_models.run_generators(
-        generators,
-        default_modes=[
-            # TODO
-            # "replace_me",
-        ],
+        generators, default_modes=["get_REST_api_sources"]
     )
 
 

--- a/pysa_tutorial/exercise4/generate_models.py
+++ b/pysa_tutorial/exercise4/generate_models.py
@@ -26,19 +26,20 @@ class Ignore:
 def main() -> None:
     # Here, specify all the generators that you might want to call.
     generators = {
-        "get_REST_api_sources": generate_taint_models.RESTApiSourceGenerator(
-            django_urls=view_generator.DjangoUrls(
-                urls_module="urls",
-                url_pattern_type=UrlPattern,
-                url_resolver_type=Ignore,
-            )
-        )
+        # TODO
+        # "replace_me": generate_taint_models.SomeGenerator(
+        #     ...
+        # ),
     }
     # The `run_generators` function will take care of parsing command-line arguments, as
     # well as executing the generators specified in `default_modes` unless you pass in a
     # specific set from the command line.
     generate_taint_models.run_generators(
-        generators, default_modes=["get_REST_api_sources"]
+        generators,
+        default_modes=[
+            # TODO
+            # "replace_me",
+        ],
     )
 
 


### PR DESCRIPTION
:mortar_board: Small `pysa_tutorial/` and `docs/pysa_precollectors.md` edits

- Added missing TODO in `exercise4/generate_models.py`
- `are` -> `is` in `docs/pysa_precollectors.md`
- Small miscellaneous edits of `pysa_tutorial/`