### PR TITLE
Add more Django model fields

### DIFF
--- a/stubs/django/db/models/__init__.pyi
+++ b/stubs/django/db/models/__init__.pyi
@@ -24,17 +24,23 @@ from django.db.models.deletion import (
 )
 from django.db.models.enums import IntegerChoices, TextChoices
 from django.db.models.fields import (
-    AutoField as AutoField,
-    BigIntegerField as BigIntegerField,
-    BooleanField as BooleanField,
-    CharField as CharField,
-    DateTimeField as DateTimeField,
-    EmailField as EmailField,
-    IntegerField as IntegerField,
-    NullBooleanField as NullBooleanField,
-    PositiveIntegerField as PositiveIntegerField,
-    PositiveSmallIntegerField as PositiveSmallIntegerField,
-    TextField as TextField,
+    AutoField,
+    BigIntegerField,
+    BooleanField,
+    CharField,
+    DateField,
+    DateTimeField,
+    DecimalField,
+    EmailField,
+    FloatField,
+    IntegerField,
+    NullBooleanField,
+    PositiveIntegerField,
+    PositiveSmallIntegerField,
+    SmallAutoField,
+    TextField,
+    TimeField,
+    URLField,
 )
 from django.db.models.fields.related import ForeignKey
 from django.db.models.fields.subclassing import SubfieldBase

--- a/stubs/django/db/models/fields/__init__.pyi
+++ b/stubs/django/db/models/fields/__init__.pyi
@@ -1,6 +1,7 @@
 # pyre-unsafe
 
 import datetime
+from decimal import Decimal
 from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 # This stub is a lie. These are all actually classes that inherit from a common
@@ -47,14 +48,39 @@ def CharField(
 
 EmailField = CharField
 TextField = CharField
+URLField = CharField
 
+def DateField(
+    verbose_name: str = ...,
+    name: str = ...,
+    auto_now: bool = ...,
+    auto_now_add: bool = ...,
+    primary_key: bool = ...,
+    unique: bool = ...,
+    blank: bool = ...,
+    null: bool = ...,
+    db_index: bool = ...,
+    rel: object = ...,
+    default: Optional[Union[Callable[[], datetime.date], datetime.date]] = ...,
+    editable: bool = ...,
+    serialize: bool = ...,
+    unique_for_date: datetime.date = ...,
+    unique_for_month: int = ...,
+    unique_for_year: int = ...,
+    choices: Sequence[Tuple[datetime.datetime, str]] = ...,
+    help_text: str = ...,
+    db_column: str = ...,
+    db_tablespace: str = ...,
+    auto_created: bool = ...,
+    validators: Sequence[Callable[[datetime.datetime], None]] = ...,
+    error_messages: Mapping[str, str] = ...,
+) -> datetime.date: ...
 def DateTimeField(
     verbose_name: str = ...,
     name: str = ...,
     auto_now: bool = ...,
     auto_now_add: bool = ...,
     primary_key: bool = ...,
-    max_length: int = ...,
     unique: bool = ...,
     blank: bool = ...,
     null: bool = ...,
@@ -74,13 +100,83 @@ def DateTimeField(
     validators: Sequence[Callable[[datetime.datetime], None]] = ...,
     error_messages: Mapping[str, str] = ...,
 ) -> datetime.datetime: ...
-def IntegerField(
+def TimeField(
     verbose_name: str = ...,
     name: str = ...,
     auto_now: bool = ...,
     auto_now_add: bool = ...,
     primary_key: bool = ...,
-    max_length: int = ...,
+    unique: bool = ...,
+    blank: bool = ...,
+    null: bool = ...,
+    db_index: bool = ...,
+    rel: object = ...,
+    default: Optional[Union[Callable[[], datetime.time], datetime.time]] = ...,
+    editable: bool = ...,
+    serialize: bool = ...,
+    unique_for_date: datetime.date = ...,
+    unique_for_month: int = ...,
+    unique_for_year: int = ...,
+    choices: Sequence[Tuple[datetime.datetime, str]] = ...,
+    help_text: str = ...,
+    db_column: str = ...,
+    db_tablespace: str = ...,
+    auto_created: bool = ...,
+    validators: Sequence[Callable[[datetime.datetime], None]] = ...,
+    error_messages: Mapping[str, str] = ...,
+) -> datetime.time: ...
+def DecimalField(
+    verbose_name: str = ...,
+    name: str = ...,
+    max_digits: Optional[int] = ...,
+    decimal_places: Optional[int] = ...,
+    primary_key: bool = ...,
+    unique: bool = ...,
+    blank: bool = ...,
+    null: bool = ...,
+    db_index: bool = ...,
+    rel: object = ...,
+    default: Optional[int] = ...,
+    editable: bool = ...,
+    serialize: bool = ...,
+    unique_for_date: datetime.date = ...,
+    unique_for_month: int = ...,
+    unique_for_year: int = ...,
+    choices: Sequence[Tuple[int, str]] = ...,
+    help_text: str = ...,
+    db_column: str = ...,
+    db_tablespace: str = ...,
+    auto_created: bool = ...,
+    validators: Sequence[Callable[[int], None]] = ...,
+    error_messages: Mapping[str, str] = ...,
+) -> Decimal: ...
+def FloatField(
+    verbose_name: str = ...,
+    name: str = ...,
+    primary_key: bool = ...,
+    unique: bool = ...,
+    blank: bool = ...,
+    null: bool = ...,
+    db_index: bool = ...,
+    rel: object = ...,
+    default: Optional[int] = ...,
+    editable: bool = ...,
+    serialize: bool = ...,
+    unique_for_date: datetime.date = ...,
+    unique_for_month: int = ...,
+    unique_for_year: int = ...,
+    choices: Sequence[Tuple[int, str]] = ...,
+    help_text: str = ...,
+    db_column: str = ...,
+    db_tablespace: str = ...,
+    auto_created: bool = ...,
+    validators: Sequence[Callable[[int], None]] = ...,
+    error_messages: Mapping[str, str] = ...,
+) -> float: ...
+def IntegerField(
+    verbose_name: str = ...,
+    name: str = ...,
+    primary_key: bool = ...,
     unique: bool = ...,
     blank: bool = ...,
     null: bool = ...,
@@ -106,14 +202,12 @@ PositiveSmallIntegerField = IntegerField
 BigIntegerField = IntegerField
 
 AutoField = IntegerField
+SmallAutoField = IntegerField
 
 def BooleanField(
     verbose_name: str = ...,
     name: str = ...,
-    auto_now: bool = ...,
-    auto_now_add: bool = ...,
     primary_key: bool = ...,
-    max_length: int = ...,
     unique: bool = ...,
     blank: bool = ...,
     null: bool = ...,
@@ -136,10 +230,7 @@ def BooleanField(
 def NullBooleanField(
     verbose_name: str = ...,
     name: str = ...,
-    auto_now: bool = ...,
-    auto_now_add: bool = ...,
     primary_key: bool = ...,
-    max_length: int = ...,
     unique: bool = ...,
     blank: bool = ...,
     null: bool = ...,


### PR DESCRIPTION
This adds the following fields to `django.db.models.fields`

* `DecimalField`
* `FloatField`
* `SmallAutoField`
* `TimeField`
* `URLField`
