### PR TITLE
Add initial stubs for BaseUserManager and UserManager

### DIFF
--- a/stubs/django/contrib/auth/base_user.pyi
+++ b/stubs/django/contrib/auth/base_user.pyi
@@ -1,0 +1,9 @@
+# pyre-unsafe
+
+from django.db import models
+
+class BaseUserManager(models.Manager):
+    pass
+
+class AbstractBaseUser(models.Model):
+    pass

--- a/stubs/django/contrib/auth/models.pyi
+++ b/stubs/django/contrib/auth/models.pyi
@@ -2,16 +2,17 @@
 
 from typing import Any, Optional
 
+from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.db import models
+
+class UserManager(BaseUserManager):
+    pass
 
 class AnonymousUser(object):
     id: Optional[int]
     is_active: bool
     def is_anonymous(self) -> bool: ...
     def is_authenticated(self) -> bool: ...
-
-class AbstractBaseUser(models.Model):
-    pass
 
 class AbstractUser(AbstractBaseUser):
     pass


### PR DESCRIPTION
These classes should be used whenever the included `User` is extended or
replaced. Like the other stubs for this module, they just establish the
types.

Because `BaseUserManager` belongs in `base_user`, not `models`, the
module it being added and `AbstractBaseUser` is being moved there as
well.