### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ $ pyre -l project
 ### Nested Local Configurations
 Nesting local configurations is not recommended. The configuration should live at the root of your
 project unit and inclusion/exclusion of files from type checking can be done by specifying sources, using
-`ignore_all_errors`, or by adding [local suppression](https://pyre-check.org/docs/error-suppression.html).
+`ignore_all_errors`, or by adding [local suppression](error_suppression.md).
 
 If in rare cases the nested configuration cannot be combined upward and the parent cannot be split apart, the
 parent configuration must list the directory containing the nested configuration in its `ignore_all_errors` field.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -23,7 +23,7 @@ machine. If you already have a Pyre installation, you can take the
 [Guided Tour](guided_tour.md) to familiarize yourself the basic workflows 
 that we recommend.
 
-The [Configuring Pyre](http://configuration.html/) section contains information 
+The [Configuring Pyre](configuration.html) section contains information 
 on how to customize Pyre to work with your own projects. You can tune Pyre in 
 a number of different ways, depending on how strict you want to be with your 
 types, and how performant you want Pyre to be when run against your source base. 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -23,22 +23,22 @@ machine. If you already have a Pyre installation, you can take the
 [Guided Tour](guided_tour.md) to familiarize yourself the basic workflows 
 that we recommend.
 
-The [Configuring Pyre](configuration.html) section contains information 
+The [Configuring Pyre](configuration.md) section contains information 
 on how to customize Pyre to work with your own projects. You can tune Pyre in 
 a number of different ways, depending on how strict you want to be with your 
 types, and how performant you want Pyre to be when run against your source base. 
 
 Pyre includes a number of key features, described in these pages:
 
-* [Gradual Typing](gradual-typing.html) - Not every expression is typed. Pyre 
+* [Gradual Typing](gradual-typing.md) - Not every expression is typed. Pyre 
    allows users to explicitly specify how strict the type checking should be 
    on a per-file basis.
-* [Error Suppression](error-suppression.html) - Pyre will suppress specified 
+* [Error Suppression](error-suppression.md) - Pyre will suppress specified 
    errors, depending on configuration. 
-* [Error Types](error-types.html) - Pyre identifies a number of different error 
+* [Error Types](error-types.md) - Pyre identifies a number of different error 
    types including incompatible variables, behavioral subtyping, missing 
    attributes, and much more. 
-* [Editor Integration](lsp-integration.html) - Pyre integrates with VS Code and 
+* [Editor Integration](lsp-integration.md) - Pyre integrates with VS Code and 
    Nuclide. 
-* [Watchman Integration](watchman-integration.html) - Allows for incremental 
+* [Watchman Integration](watchman-integration.md) - Allows for incremental 
    typechecking using terminal editors such as Vim or Emacs.

--- a/docs/static_analysis_post_processor.md
+++ b/docs/static_analysis_post_processor.md
@@ -18,7 +18,7 @@ then you already have the `sapp` binary installed.
 ## Example
 
 This assumes you have followed the
-["Running Pysa" example](./pysa-running.html#example) already.
+["Running Pysa" example](pysa_running.md#example) already.
 
 ### Parsing the JSON
 


### PR DESCRIPTION
Fixed a broken link on the overview page.
Unified local file linking style from mixing html with markdown to markdown only,
as it fixes document navigation in previews for [views like this](https://github.com/facebook/pyre-check/blob/master/docs/overview.md)