### PR TITLE
Export redirected Django imports

### DIFF
--- a/stubs/django/core/mail/__init__.pyi
+++ b/stubs/django/core/mail/__init__.pyi
@@ -3,7 +3,11 @@
 from email.mime.base import MIMEBase
 from typing import Any, Iterable, Optional, Tuple, Union
 
-from django.core.mail.message import EmailMessage, SafeMIMEMultipart, SafeMIMEText
+from django.core.mail.message import (
+    EmailMessage as EmailMessage,
+    SafeMIMEMultipart as SafeMIMEMultipart,
+    SafeMIMEText as SafeMIMEText,
+)
 
 def send_mail(
     subject: Any,

--- a/stubs/django/db/models/__init__.pyi
+++ b/stubs/django/db/models/__init__.pyi
@@ -15,36 +15,39 @@ from django.db.aggregates import (
     Variance as Variance,
 )
 from django.db.models.deletion import (
-    CASCADE,
-    DO_NOTHING,
-    PROTECT,
-    RESTRICT,
-    SET_DEFAULT,
-    SET_NULL,
+    CASCADE as CASCADE,
+    DO_NOTHING as DO_NOTHING,
+    PROTECT as PROTECT,
+    RESTRICT as RESTRICT,
+    SET_DEFAULT as SET_DEFAULT,
+    SET_NULL as SET_NULL,
 )
-from django.db.models.enums import IntegerChoices, TextChoices
+from django.db.models.enums import (
+    IntegerChoices as IntegerChoices,
+    TextChoices as TextChoices,
+)
 from django.db.models.fields import (
-    AutoField,
-    BigIntegerField,
-    BooleanField,
-    CharField,
-    DateField,
-    DateTimeField,
-    DecimalField,
-    EmailField,
-    FloatField,
-    IntegerField,
-    NullBooleanField,
-    PositiveIntegerField,
-    PositiveSmallIntegerField,
-    SmallAutoField,
-    TextField,
-    TimeField,
-    URLField,
+    AutoField as AutoField,
+    BigIntegerField as BigIntegerField,
+    BooleanField as BooleanField,
+    CharField as CharField,
+    DateField as DateField,
+    DateTimeField as DateTimeField,
+    DecimalField as DecimalField,
+    EmailField as EmailField,
+    FloatField as FloatField,
+    IntegerField as IntegerField,
+    NullBooleanField as NullBooleanField,
+    PositiveIntegerField as PositiveIntegerField,
+    PositiveSmallIntegerField as PositiveSmallIntegerField,
+    SmallAutoField as SmallAutoField,
+    TextField as TextField,
+    TimeField as TimeField,
+    URLField as URLField,
 )
-from django.db.models.fields.related import ForeignKey
-from django.db.models.fields.subclassing import SubfieldBase
-from django.db.models.manager import Manager
+from django.db.models.fields.related import ForeignKey as ForeignKey
+from django.db.models.fields.subclassing import SubfieldBase as SubfieldBase
+from django.db.models.manager import Manager as Manager
 from django.db.models.options import Options
 
 class Model:

--- a/stubs/django/dispatch/__init__.pyi
+++ b/stubs/django/dispatch/__init__.pyi
@@ -1,1 +1,1 @@
-from django.dispatch.dispatcher import Signal, receiver
+from django.dispatch.dispatcher import Signal as Signal, receiver as receiver

--- a/stubs/django/forms/__init__.pyi
+++ b/stubs/django/forms/__init__.pyi
@@ -1,12 +1,12 @@
-from django.core.exceptions import ValidationError
-from django.forms.fields import BooleanField, EmailField
-from django.forms.forms import Form
-from django.forms.models import ModelForm
+from django.core.exceptions import ValidationError as ValidationError
+from django.forms.fields import BooleanField as BooleanField, EmailField as EmailField
+from django.forms.forms import Form as Form
+from django.forms.models import ModelForm as ModelForm
 from django.forms.widgets import (
-    CheckboxInput,
-    EmailInput,
-    HiddenInput,
-    NumberInput,
-    TextInput,
-    URLInput,
+    CheckboxInput as CheckboxInput,
+    EmailInput as EmailInput,
+    HiddenInput as HiddenInput,
+    NumberInput as NumberInput,
+    TextInput as TextInput,
+    URLInput as URLInput,
 )

--- a/stubs/django/http/__init__.pyi
+++ b/stubs/django/http/__init__.pyi
@@ -1,15 +1,22 @@
-from django.http.cookie import SimpleCookie
-from django.http.request import HttpRequest, QueryDict, build_request_repr
-from django.http.response import (
-    Http404,
-    HttpResponse,
-    HttpResponseBadRequest,
-    HttpResponseForbidden,
-    HttpResponseNotAllowed,
-    HttpResponseNotFound,
-    HttpResponsePermanentRedirect,
-    HttpResponseRedirect,
-    HttpResponseServerError,
-    StreamingHttpResponse,
+from django.http.cookie import SimpleCookie as SimpleCookie
+from django.http.request import (
+    HttpRequest as HttpRequest,
+    QueryDict as QueryDict,
+    build_request_repr as build_request_repr,
 )
-from django.http.utils import conditional_content_removal, fix_location_header
+from django.http.response import (
+    Http404 as Http404,
+    HttpResponse as HttpResponse,
+    HttpResponseBadRequest as HttpResponseBadRequest,
+    HttpResponseForbidden as HttpResponseForbidden,
+    HttpResponseNotAllowed as HttpResponseNotAllowed,
+    HttpResponseNotFound as HttpResponseNotFound,
+    HttpResponsePermanentRedirect as HttpResponsePermanentRedirect,
+    HttpResponseRedirect as HttpResponseRedirect,
+    HttpResponseServerError as HttpResponseServerError,
+    StreamingHttpResponse as StreamingHttpResponse,
+)
+from django.http.utils import (
+    conditional_content_removal as conditional_content_removal,
+    fix_location_header as fix_location_header,
+)

--- a/stubs/django/test/__init__.pyi
+++ b/stubs/django/test/__init__.pyi
@@ -2,8 +2,8 @@
 
 from unittest import TestCase
 
-from django.test.client import Client
-from django.test.utils import override_settings
+from django.test.client import Client as Client
+from django.test.utils import override_settings as override_settings
 
 class SimpleTestCase(TestCase):
     client: testing.client.base.TestClient = ...

--- a/stubs/django/urls/__init__.pyi
+++ b/stubs/django/urls/__init__.pyi
@@ -1,25 +1,25 @@
 from .base import (
-    clear_script_prefix,
-    clear_url_caches,
-    get_script_prefix,
-    get_urlconf,
-    is_valid_path,
-    resolve,
-    reverse,
-    reverse_lazy,
-    set_script_prefix,
-    set_urlconf,
-    translate_url,
+    clear_script_prefix as clear_script_prefix,
+    clear_url_caches as clear_url_caches,
+    get_script_prefix as get_script_prefix,
+    get_urlconf as get_urlconf,
+    is_valid_path as is_valid_path,
+    resolve as resolve,
+    reverse as reverse,
+    reverse_lazy as reverse_lazy,
+    set_script_prefix as set_script_prefix,
+    set_urlconf as set_urlconf,
+    translate_url as translate_url,
 )
-from .conf import include, path, re_path
-from .converters import register_converter
-from .exceptions import NoReverseMatch, Resolver404
+from .conf import include as include, path as path, re_path as re_path
+from .converters import register_converter as register_converter
+from .exceptions import NoReverseMatch as NoReverseMatch, Resolver404 as Resolver404
 from .resolvers import (
-    LocalePrefixPattern,
-    ResolverMatch,
-    URLPattern,
-    URLResolver,
-    get_ns_resolver,
-    get_resolver,
+    LocalePrefixPattern as LocalePrefixPattern,
+    ResolverMatch as ResolverMatch,
+    URLPattern as URLPattern,
+    URLResolver as URLResolver,
+    get_ns_resolver as get_ns_resolver,
+    get_resolver as get_resolver,
 )
-from .utils import get_callable, get_mod_func
+from .utils import get_callable as get_callable, get_mod_func as get_mod_func


### PR DESCRIPTION
As per [PEP 484], an import in a stub file isn't considered exported
from the stub unless the import includes `as`. This will address this
for all of the imports that I could easily tell were intended to be
exported.

Fixes #287

[PEP 484]: https://www.python.org/dev/peps/pep-0484/#stub-files
