### PR TITLE
[documentation] fix colors in table of content

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -29,3 +29,11 @@
 .navbar__link {
   margin-top: 15px;
 }
+
+.table-of-contents__link:hover {
+  color:#c25725;
+}
+
+.table-of-contents__link--active {
+  color:#c25725;
+}


### PR DESCRIPTION
Note that we're working around the theme here because docosaurus unfortunately ties the color of the menu to the color of the background on the front-page. #cantexplainthat

<img width="1085" alt="Screenshot 2020-08-04 14 42 13" src="https://user-images.githubusercontent.com/270421/89348117-e0815c00-d660-11ea-9850-5e51d2151d63.png">
