### PR TITLE
Constraints on ListVariadics

### DIFF
--- a/analysis/analysisError.ml
+++ b/analysis/analysisError.ml
@@ -1173,6 +1173,16 @@ let rec messages ~concise ~signature location kind =
           (Type.Variable expected)
           name;
       ]
+  | InvalidTypeParameters
+      { name; kind = AttributeResolution.ViolateConstraintsVariadic { expected; actual } } ->
+      [
+        Format.asprintf
+          "Type parameter list `%a` violates constraints on `%s` in generic type `%s`."
+          (Type.Record.OrderedTypes.pp_concise ~pp_type)
+          actual
+          (Type.Record.Variable.RecordVariadic.RecordList.name expected)
+          name;
+      ]
   | InvalidTypeParameters { name; kind = AttributeResolution.UnexpectedKind { expected; actual } }
     ->
       let details =
@@ -3453,6 +3463,9 @@ let dequalify
               actual = dequalify actual;
               expected = Type.Variable.Unary.dequalify ~dequalify_map expected;
             }
+      | AttributeResolution.ViolateConstraintsVariadic { actual; expected } ->
+          AttributeResolution.ViolateConstraintsVariadic
+            { actual; expected = Type.Variable.Variadic.List.dequalify ~dequalify_map expected }
       | AttributeResolution.UnexpectedKind { actual; expected } ->
           AttributeResolution.UnexpectedKind
             { actual; expected = Type.Variable.dequalify dequalify_map expected }

--- a/analysis/attributeResolution.ml
+++ b/analysis/attributeResolution.ml
@@ -169,6 +169,10 @@ module TypeParameterValidationTypes = struct
         actual: Type.t;
         expected: Type.Variable.Unary.t;
       }
+    | ViolateConstraintsVariadic of {
+        actual: Type.OrderedTypes.t;
+        expected: Type.Variable.Variadic.List.t;
+      }
     | UnexpectedKind of {
         actual: Type.Parameter.t;
         expected: Type.Variable.t;
@@ -821,7 +825,7 @@ class base class_metadata_environment dependency =
                             TypeConstraints.empty
                             ~order
                             ~pair
-                          >>| TypeOrder.OrderedConstraints.add_upper_bound ~order ~pair
+                          >>= TypeOrder.OrderedConstraints.add_upper_bound ~order ~pair
                           |> Option.is_none
                         in
                         if invalid then
@@ -848,10 +852,29 @@ class base class_metadata_environment dependency =
                         ( CallableParameters Undefined,
                           Some
                             { name; kind = UnexpectedKind { expected = generic; actual = given } } )
-                    | ParameterVariadic _, CallableParameters _
-                    | ListVariadic _, Group _ ->
+                    | ParameterVariadic _, CallableParameters _ -> given, None
+                    | ListVariadic generic, Group given ->
                         (* TODO(T47346673): accept w/ new kind of validation *)
-                        given, None
+                        let invalid =
+                          let order = self#full_order ~assumptions in
+                          let pair = Type.Variable.ListVariadicPair (generic, given) in
+                          TypeOrder.OrderedConstraints.add_lower_bound
+                            TypeConstraints.empty
+                            ~order
+                            ~pair
+                          >>= TypeOrder.OrderedConstraints.add_upper_bound ~order ~pair
+                          |> Option.is_none
+                        in
+                        if invalid then
+                          ( Type.Parameter.Group Any,
+                            Some
+                              {
+                                name;
+                                kind =
+                                  ViolateConstraintsVariadic { actual = given; expected = generic };
+                              } )
+                        else
+                          Type.Parameter.Group given, None
                   in
                   List.map paired ~f:check_parameter
                   |> List.unzip

--- a/analysis/attributeResolution.mli
+++ b/analysis/attributeResolution.mli
@@ -34,6 +34,10 @@ type generic_type_problems =
       actual: Type.t;
       expected: Type.Variable.Unary.t;
     }
+  | ViolateConstraintsVariadic of {
+      actual: Type.OrderedTypes.t;
+      expected: Type.Variable.Variadic.List.t;
+    }
   | UnexpectedKind of {
       actual: Type.Parameter.t;
       expected: Type.Variable.t;

--- a/analysis/test/typeTest.ml
+++ b/analysis/test/typeTest.ml
@@ -2082,7 +2082,16 @@ let test_parse_type_variable_declarations _ =
   assert_parses_declaration
     "pyre_extensions.ListVariadic('Ts')"
     (Type.Variable.ListVariadic (Type.Variable.Variadic.List.create "target"));
-  assert_declaration_does_not_parse "pyre_extensions.ListVariadic('Ts', int, str)";
+  assert_parses_declaration
+    "pyre_extensions.ListVariadic('Ts', int, str)"
+    (Type.Variable.ListVariadic
+       (Type.Variable.Variadic.List.create
+          "target"
+          ~constraints:(Explicit [Type.Primitive "int"; Type.Primitive "str"])));
+  assert_parses_declaration
+    "pyre_extensions.ListVariadic('Ts', bound=int)"
+    (Type.Variable.ListVariadic
+       (Type.Variable.Variadic.List.create "target" ~constraints:(Bound (Type.Primitive "int"))));
   ()
 
 

--- a/analysis/type.mli
+++ b/analysis/type.mli
@@ -50,7 +50,16 @@ module Record : sig
       end
 
       module RecordList : sig
-        type 'annotation record [@@deriving compare, eq, sexp, show, hash]
+        type 'annotation record = {
+          name: Identifier.t;
+          constraints: 'annotation constraints;
+          variance: variance;
+          state: state;
+          namespace: RecordNamespace.t;
+        }
+        [@@deriving compare, eq, sexp, show, hash]
+
+        val name : 'a record -> string
       end
     end
 
@@ -64,10 +73,24 @@ module Record : sig
   module OrderedTypes : sig
     module RecordConcatenate : sig
       module Middle : sig
-        type 'annotation t [@@deriving compare, eq, sexp, show, hash]
+        type 'annotation t = {
+          variable: 'annotation Variable.RecordVariadic.RecordList.record;
+          mappers: Identifier.t list;
+        }
+        [@@deriving compare, eq, sexp, show, hash]
       end
 
-      type ('middle, 'outer) t [@@deriving compare, eq, sexp, show, hash]
+      type 'annotation wrapping = {
+        head: 'annotation list;
+        tail: 'annotation list;
+      }
+      [@@deriving compare, eq, sexp, show, hash]
+
+      type ('middle, 'annotation) t = {
+        middle: 'middle;
+        wrapping: 'annotation wrapping;
+      }
+      [@@deriving compare, eq, sexp, show, hash]
     end
 
     type 'annotation record =

--- a/pyre_extensions/__init__.py
+++ b/pyre_extensions/__init__.py
@@ -92,7 +92,7 @@ class ParameterSpecification(list):
         pass
 
 
-def ListVariadic(name) -> object:
+def ListVariadic(name, bound=None) -> object:
     return Any
 
 


### PR DESCRIPTION
Summary:
This diff brings support for constraints on ListVariadics. The constraints that can be specified are the same as for TypeVar, that is, Bounds and Explicits. Although ListVariadics currently could infer the bounds based on other values of the concatenation, this approach is too limited.

While Pyre had already internal support to express that a ListVariadic has constraints, all the logic related with it was empty, since it was not allow to directly specify the constraint of a ListVariadic. For that purpose, this diff defines the required logic, mostly the propagation of constraints to ensure that violation of constraints are identified, as well as subtyping between the various combinations of variadics.

Since subtyping of variables can be ambiguous, we support every case except when given something reduced to `[...,A,Ts1] <: [Ts2,B,...]`.

Finally, since parse_declaration does not have access to create_logic, currently only primitive types can be used as constraints, for that purpose a follow up diff is proposed. See comment:  https://www.internalfb.com/intern/diff/D23342739/?dest_fbid=606703123545772&transaction_id=343730890366364

Differential Revision: D23342739

