### PR TITLE
Import Any inside placeholder Django stubs

### DIFF
--- a/stubs/django/apps.pyi
+++ b/stubs/django/apps.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/conf/wsgi.pyi
+++ b/stubs/django/conf/wsgi.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/contrib/admin.pyi
+++ b/stubs/django/contrib/admin.pyi
@@ -3,4 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...

--- a/stubs/django/contrib/auth/decorators.pyi
+++ b/stubs/django/contrib/auth/decorators.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/contrib/auth/hashers.pyi
+++ b/stubs/django/contrib/auth/hashers.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/contrib/auth/tokens.pyi
+++ b/stubs/django/contrib/auth/tokens.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/contrib/gis/geos/point.pyi
+++ b/stubs/django/contrib/gis/geos/point.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/contrib/sites.pyi
+++ b/stubs/django/contrib/sites.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/core/management/commands/test.pyi
+++ b/stubs/django/core/management/commands/test.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/core/servers/basehttp.pyi
+++ b/stubs/django/core/servers/basehttp.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/core/signals.pyi
+++ b/stubs/django/core/signals.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/core/wsgi.pyi
+++ b/stubs/django/core/wsgi.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/db/models/fields/related.pyi
+++ b/stubs/django/db/models/fields/related.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/db/models/query.pyi
+++ b/stubs/django/db/models/query.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/db/models/signals.pyi
+++ b/stubs/django/db/models/signals.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/db/models/sql/where.pyi
+++ b/stubs/django/db/models/sql/where.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/http/multipartparser.pyi
+++ b/stubs/django/http/multipartparser.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/middleware/cache.pyi
+++ b/stubs/django/middleware/cache.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/middleware/http.pyi
+++ b/stubs/django/middleware/http.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/template/loader.pyi
+++ b/stubs/django/template/loader.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/template/loaders.pyi
+++ b/stubs/django/template/loaders.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/template/utils.pyi
+++ b/stubs/django/template/utils.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/urls/converters.pyi
+++ b/stubs/django/urls/converters.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/urls/exceptions.pyi
+++ b/stubs/django/urls/exceptions.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/urls/resolvers.pyi
+++ b/stubs/django/urls/resolvers.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/urls/utils.pyi
+++ b/stubs/django/urls/utils.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/_os.pyi
+++ b/stubs/django/utils/_os.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/dateparse.pyi
+++ b/stubs/django/utils/dateparse.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/dates.pyi
+++ b/stubs/django/utils/dates.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/decorators.pyi
+++ b/stubs/django/utils/decorators.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/deprecation.pyi
+++ b/stubs/django/utils/deprecation.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/duration.pyi
+++ b/stubs/django/utils/duration.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/formats.pyi
+++ b/stubs/django/utils/formats.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/importlib.pyi
+++ b/stubs/django/utils/importlib.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/ipv6.pyi
+++ b/stubs/django/utils/ipv6.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/module_loading.pyi
+++ b/stubs/django/utils/module_loading.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/utils/six/moves/urllib/parse.pyi
+++ b/stubs/django/utils/six/moves/urllib/parse.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.

--- a/stubs/django/views.pyi
+++ b/stubs/django/views.pyi
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any
+
 def __getattr__(name: str) -> Any: ...
 
 # Placeholder stub.


### PR DESCRIPTION
A lot of the placeholder stubs for Django use

    def __getattr__(name: str) -> Any: ...

to allow typechecks to pass before the module has actually been typed.
Unfortunately this can introduce errors stating that `Any` isn't defined.

This change will import `Any` into all of the placeholder stubs to avoid
this error.
