### PR TITLE
Make exercise 5 easier to uncomment.

### DIFF
--- a/pysa_tutorial/exercise5/generate_models.py
+++ b/pysa_tutorial/exercise5/generate_models.py
@@ -40,7 +40,7 @@ def main() -> None:
                 url_pattern_type=UrlPattern,
                 url_resolver_type=Ignore,
             )
-        )  # ,
+        ),
         # "decorator_extracted_params": generate_taint_models.<GENERATOR_NAME>(
         #     root=".",
         #     annotation_specifications=[
@@ -57,7 +57,7 @@ def main() -> None:
     generate_taint_models.run_generators(
         generators,
         default_modes=[
-            "django_path_params"  # ,
+            "django_path_params",
             # "decorator_extracted_params"
         ],
     )


### PR DESCRIPTION
Exercise 5 requires uncommenting some lines, but it uses both line comments and *inline* comments which makes it somewhat fiddly: most editors have a command to (un)comment lines or entire blocks at once, not so for inline comments.

However the inline comments seem unnecessary: they just comment trailing commas, which Python is perfectly fine with. By removing those, it becomes possible to just point to or select the offending line and bulk-uncomment them via whatever editor feature does that, which is quite a bit simpler.