### PR TITLE
Broadcast on variadics

### DIFF
--- a/analysis/analysisError.ml
+++ b/analysis/analysisError.ml
@@ -1228,8 +1228,10 @@ let rec messages ~concise ~signature location kind =
       in
       let actual =
         match actual with
-        | Group actual ->
-            Format.asprintf "type parameter group `[%a]`" Type.OrderedTypes.pp_concise actual
+        | VariadicExpression (Group actual) ->
+            Format.asprintf "type parameter group `[%a]`" Type.OrderedTypes.pp_concise_record actual
+        | VariadicExpression expression ->
+            Format.asprintf "type parameter group `%a`" Type.OrderedTypes.pp_concise expression
         | Single actual -> Format.asprintf "single type `%a`" Type.pp actual
         | CallableParameters actual ->
             Format.asprintf "callable parameters `%a`" Type.Callable.pp_parameters actual

--- a/analysis/test/annotatedBasesTest.ml
+++ b/analysis/test/annotatedBasesTest.ml
@@ -129,7 +129,7 @@ let test_inferred_generic_base context =
             (Type.parametric
                "typing.Generic"
                [
-                 Type.Parameter.Group
+                 Type.Parameter.VariadicExpression
                    (Type.Variable.Variadic.List.self_reference
                       (Type.Variable.Variadic.List.create "test.Ts"));
                ]);

--- a/analysis/test/annotatedSignatureTest.ml
+++ b/analysis/test/annotatedSignatureTest.ml
@@ -782,10 +782,8 @@ let test_unresolved_select context =
           (SignatureSelectionTypes.MismatchWithListVariadicTypeVariable
              {
                variable =
-                 Concatenation
-                   (Type.OrderedTypes.Concatenation.create
-                      (Type.OrderedTypes.Concatenation.Middle.create_bare
-                         (Type.Variable.Variadic.List.create "test.Ts")));
+                 Type.Variable.Variadic.List.self_reference
+                   (Type.Variable.Variadic.List.create "test.Ts");
                mismatch =
                  NotDefiniteTuple
                    {
@@ -803,11 +801,9 @@ let test_unresolved_select context =
           (SignatureSelectionTypes.MismatchWithListVariadicTypeVariable
              {
                variable =
-                 Concatenation
-                   (Type.OrderedTypes.Concatenation.create
-                      (Type.OrderedTypes.Concatenation.Middle.create_bare
-                         (Type.Variable.Variadic.List.create "test.Ts")));
-               mismatch = ConstraintFailure (Concrete [Type.float]);
+                 Type.Variable.Variadic.List.self_reference
+                   (Type.Variable.Variadic.List.create "test.Ts");
+               mismatch = ConstraintFailure (Group (Concrete [Type.float]));
              }) ));
   assert_select
     "[pyre_extensions.type_variable_operators.Map[typing.List, Ts], int]"

--- a/analysis/test/constraintsSetTest.ml
+++ b/analysis/test/constraintsSetTest.ml
@@ -250,10 +250,10 @@ let test_add_constraint context =
               in
               let parse_ordered_types ordered =
                 if String.equal ordered "" then
-                  Type.OrderedTypes.Concrete []
+                  Type.OrderedTypes.Group (Concrete [])
                 else
                   match parse_annotation (Printf.sprintf "typing.Tuple[%s]" ordered) with
-                  | Type.Tuple (Bounded ordered) -> ordered
+                  | Type.Tuple (Bounded ordered) -> Group ordered
                   | _ -> failwith "impossible"
               in
               let global_resolution =
@@ -1114,7 +1114,7 @@ let test_instantiate_protocol_parameters context =
     ~protocols:["VariadicCol", ["prop", "typing.Tuple[Ts]"]]
     ~candidate:"A"
     ~protocol:"VariadicCol"
-    (Some [Group (Concrete [Type.integer; Type.string])]);
+    (Some [VariadicExpression (Group (Concrete [Type.integer; Type.string]))]);
   assert_instantiate_protocol_parameters
     ~source:
       {|
@@ -1125,7 +1125,7 @@ let test_instantiate_protocol_parameters context =
     ~protocols:["VariadicCol", ["method", "typing.Callable[Ts, bool]"]]
     ~candidate:"A"
     ~protocol:"VariadicCol"
-    (Some [Group (Concrete [Type.integer; Type.string])]);
+    (Some [VariadicExpression (Group (Concrete [Type.integer; Type.string]))]);
   ()
 
 

--- a/analysis/test/typeCheckTest.ml
+++ b/analysis/test/typeCheckTest.ml
@@ -846,7 +846,8 @@ let test_forward_expression context =
       pass
   |}
     "test.MyVariadic[int]"
-    (Type.meta (Type.parametric "test.MyVariadic" [Group (Concrete [Type.integer])]));
+    (Type.meta
+       (Type.parametric "test.MyVariadic" [VariadicExpression (Group (Concrete [Type.integer]))]));
   assert_forward
     ~environment:
       {|
@@ -856,7 +857,10 @@ let test_forward_expression context =
       pass
   |}
     "test.MyVariadic[int, str]"
-    (Type.meta (Type.parametric "test.MyVariadic" [Group (Concrete [Type.integer; Type.string])]));
+    (Type.meta
+       (Type.parametric
+          "test.MyVariadic"
+          [VariadicExpression (Group (Concrete [Type.integer; Type.string]))]));
   (* We'd like for this to return typing.Type[MyVariadic[int, [bool, float]]], but we lose track of
      the inner types of the lists, since they're not tuples. *)
   assert_forward
@@ -869,7 +873,8 @@ let test_forward_expression context =
       pass
   |}
     "test.MyVariadic[int, [bool, float]]"
-    (Type.meta (Type.parametric "test.MyVariadic" [Single Type.integer; Group Any]));
+    (Type.meta
+       (Type.parametric "test.MyVariadic" [Single Type.integer; VariadicExpression (Group Any)]));
 
   (* Resolved annotation field. *)
   let assert_annotation ?(precondition = []) ?(environment = "") expression annotation =

--- a/analysis/test/typeConstraintsTest.ml
+++ b/analysis/test/typeConstraintsTest.ml
@@ -23,15 +23,18 @@ let right_parent = Type.Primitive "right_parent"
 
 let grandparent = Type.Primitive "Grandparent"
 
-let create_concatenation ?head ?tail ?mappers variable
-    : (Type.t Type.OrderedTypes.Concatenation.Middle.t, Type.t) Type.OrderedTypes.Concatenation.t
-  =
+let create_concatenation ?head ?tail ?mappers variable =
   let mappers = Option.value mappers ~default:[] in
-  Type.OrderedTypes.Concatenation.create
-    ?head
-    ?tail
-    (Type.OrderedTypes.Concatenation.Middle.create ~mappers ~variable)
+  let variable = Type.OrderedTypes.Concatenation.Middle.Variadic variable in
+  Type.OrderedTypes.Group
+    (Concatenation
+       (Type.OrderedTypes.Concatenation.create
+          ?head
+          ?tail
+          (Type.OrderedTypes.Concatenation.Middle.create ~mappers ~variable)))
 
+
+let wrap_concrete list = Type.OrderedTypes.Group (Concrete list)
 
 module DiamondOrder = struct
   type t = unit
@@ -138,25 +141,19 @@ let test_add_bound _ =
          )));
   let list_variadic = Type.Variable.Variadic.List.create in
   assert_add_bound_succeeds
-    (`Lower
-      (ListVariadicPair (list_variadic "Ts", Type.OrderedTypes.Concrete [Type.integer; Type.string])));
+    (`Lower (ListVariadicPair (list_variadic "Ts", wrap_concrete [Type.integer; Type.string])));
   assert_add_bound_succeeds
     ~preconstraints:
       (add_bound
          (Some empty)
-         (`Lower
-           (ListVariadicPair
-              (list_variadic "Ts", Type.OrderedTypes.Concrete [Type.integer; Type.string]))))
-    (`Lower
-      (ListVariadicPair (list_variadic "Ts", Type.OrderedTypes.Concrete [Type.bool; Type.bool])));
+         (`Lower (ListVariadicPair (list_variadic "Ts", wrap_concrete [Type.integer; Type.string]))))
+    (`Lower (ListVariadicPair (list_variadic "Ts", wrap_concrete [Type.bool; Type.bool])));
   assert_add_bound_fails
     ~preconstraints:
       (add_bound
          (Some empty)
-         (`Lower
-           (ListVariadicPair
-              (list_variadic "Ts", Type.OrderedTypes.Concrete [Type.integer; Type.string]))))
-    (`Lower (ListVariadicPair (list_variadic "Ts", Type.OrderedTypes.Concrete [Type.bool])));
+         (`Lower (ListVariadicPair (list_variadic "Ts", wrap_concrete [Type.integer; Type.string]))))
+    (`Lower (ListVariadicPair (list_variadic "Ts", wrap_concrete [Type.bool])));
   ()
 
 
@@ -307,35 +304,34 @@ let test_single_variable_solution _ =
   let list_variadic = Type.Variable.Variadic.List.create "Ts" in
   assert_solution
     ~sequentially_applied_bounds:
-      [`Lower (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child]))]
-    (Some [ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child])]);
+      [`Lower (ListVariadicPair (list_variadic, wrap_concrete [left_parent; child]))]
+    (Some [ListVariadicPair (list_variadic, wrap_concrete [left_parent; child])]);
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child]));
-        `Lower (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [right_parent; child]));
+        `Lower (ListVariadicPair (list_variadic, wrap_concrete [left_parent; child]));
+        `Lower (ListVariadicPair (list_variadic, wrap_concrete [right_parent; child]));
       ]
-    (Some [ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [grandparent; child])]);
+    (Some [ListVariadicPair (list_variadic, wrap_concrete [grandparent; child])]);
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child]));
-        `Lower
-          (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [right_parent; child; child]));
+        `Lower (ListVariadicPair (list_variadic, wrap_concrete [left_parent; child]));
+        `Lower (ListVariadicPair (list_variadic, wrap_concrete [right_parent; child; child]));
       ]
     None;
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child]));
-        `Upper (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [grandparent; child]));
+        `Lower (ListVariadicPair (list_variadic, wrap_concrete [left_parent; child]));
+        `Upper (ListVariadicPair (list_variadic, wrap_concrete [grandparent; child]));
       ]
-    (Some [ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child])]);
+    (Some [ListVariadicPair (list_variadic, wrap_concrete [left_parent; child])]);
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [left_parent; child]));
-        `Upper (ListVariadicPair (list_variadic, Type.OrderedTypes.Concrete [right_parent; child]));
+        `Lower (ListVariadicPair (list_variadic, wrap_concrete [left_parent; child]));
+        `Upper (ListVariadicPair (list_variadic, wrap_concrete [right_parent; child]));
       ]
     None;
   assert_solution
@@ -465,15 +461,13 @@ let test_multiple_variable_solution _ =
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower
-          (ListVariadicPair (list_variadic_a, Concatenation (create_concatenation list_variadic_b)));
-        `Lower
-          (ListVariadicPair (list_variadic_b, Type.OrderedTypes.Concrete [Type.integer; Type.string]));
+        `Lower (ListVariadicPair (list_variadic_a, create_concatenation list_variadic_b));
+        `Lower (ListVariadicPair (list_variadic_b, wrap_concrete [Type.integer; Type.string]));
       ]
     (Some
        [
-         ListVariadicPair (list_variadic_a, Type.OrderedTypes.Concrete [Type.integer; Type.string]);
-         ListVariadicPair (list_variadic_b, Type.OrderedTypes.Concrete [Type.integer; Type.string]);
+         ListVariadicPair (list_variadic_a, wrap_concrete [Type.integer; Type.string]);
+         ListVariadicPair (list_variadic_b, wrap_concrete [Type.integer; Type.string]);
        ]);
 
   (* As with unaries, this trivial loop could be solvable, but we are choosing not to deal with this
@@ -481,44 +475,38 @@ let test_multiple_variable_solution _ =
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower
-          (ListVariadicPair (list_variadic_a, Concatenation (create_concatenation list_variadic_b)));
-        `Lower
-          (ListVariadicPair (list_variadic_b, Concatenation (create_concatenation list_variadic_a)));
+        `Lower (ListVariadicPair (list_variadic_a, create_concatenation list_variadic_b));
+        `Lower (ListVariadicPair (list_variadic_b, create_concatenation list_variadic_a));
       ]
     None;
   assert_solution
     ~sequentially_applied_bounds:
       [
-        `Lower
-          (ListVariadicPair
-             (list_variadic_a, Type.OrderedTypes.Concrete [Type.Variable unconstrained_a]));
+        `Lower (ListVariadicPair (list_variadic_a, wrap_concrete [Type.Variable unconstrained_a]));
         `Lower (UnaryPair (unconstrained_a, Type.integer));
       ]
     (Some
        [
-         ListVariadicPair (list_variadic_a, Type.OrderedTypes.Concrete [Type.integer]);
+         ListVariadicPair (list_variadic_a, wrap_concrete [Type.integer]);
          UnaryPair (unconstrained_a, Type.integer);
        ]);
   assert_solution
     ~sequentially_applied_bounds:
       [
         `Lower
-          (ListVariadicPair
-             (list_variadic_a, Concatenation (create_concatenation ~mappers:["Foo"] list_variadic_b)));
-        `Lower
-          (ListVariadicPair (list_variadic_b, Type.OrderedTypes.Concrete [Type.integer; Type.string]));
+          (ListVariadicPair (list_variadic_a, create_concatenation ~mappers:["Foo"] list_variadic_b));
+        `Lower (ListVariadicPair (list_variadic_b, wrap_concrete [Type.integer; Type.string]));
       ]
     (Some
        [
          ListVariadicPair
            ( list_variadic_a,
-             Concrete
+             wrap_concrete
                [
-                 Parametric { name = "Foo"; parameters = [Single Type.integer] };
+                 Type.Parametric { name = "Foo"; parameters = [Single Type.integer] };
                  Parametric { name = "Foo"; parameters = [Single Type.string] };
                ] );
-         ListVariadicPair (list_variadic_b, Type.OrderedTypes.Concrete [Type.integer; Type.string]);
+         ListVariadicPair (list_variadic_b, wrap_concrete [Type.integer; Type.string]);
        ]);
   assert_solution
     ~sequentially_applied_bounds:
@@ -609,12 +597,10 @@ let test_partial_solution _ =
     ~variables:[Type.Variable.ListVariadic list_variadic_a]
     ~bounds:
       [
-        `Lower
-          (ListVariadicPair (list_variadic_a, Concatenation (create_concatenation list_variadic_b)));
-        `Lower
-          (ListVariadicPair (list_variadic_b, Concatenation (create_concatenation list_variadic_a)));
+        `Lower (ListVariadicPair (list_variadic_a, create_concatenation list_variadic_b));
+        `Lower (ListVariadicPair (list_variadic_b, create_concatenation list_variadic_a));
       ]
-    (Some [ListVariadicPair (list_variadic_a, Concatenation (create_concatenation list_variadic_b))])
+    (Some [ListVariadicPair (list_variadic_a, create_concatenation list_variadic_b)])
     (Some []);
   ()
 
@@ -660,8 +646,7 @@ let test_exists _ =
   let list_variadic_b = Type.Variable.Variadic.List.create "TsB" in
   let constraints_with_list_variadic_b =
     let pair =
-      Type.Variable.ListVariadicPair
-        (list_variadic_a, Concatenation (create_concatenation list_variadic_b))
+      Type.Variable.ListVariadicPair (list_variadic_a, create_concatenation list_variadic_b)
     in
     DiamondOrderedConstraints.add_lower_bound TypeConstraints.empty ~order ~pair
     |> function

--- a/analysis/test/typeOrderTest.ml
+++ b/analysis/test/typeOrderTest.ml
@@ -657,9 +657,14 @@ let test_less_or_equal context =
        ~left:(Type.tuple [Type.integer; Type.float])
        ~right:(Type.Tuple (Type.Unbounded Type.float)));
   let list_variadic =
-    Type.Variable.Variadic.List.create "Ts"
-    |> Type.Variable.Variadic.List.mark_as_bound
-    |> Type.Variable.Variadic.List.self_reference
+    let variadic =
+      Type.Variable.Variadic.List.create "Ts" |> Type.Variable.Variadic.List.mark_as_bound
+    in
+    let middle =
+      Type.OrderedTypes.Concatenation.Middle.Variadic variadic
+      |> Type.OrderedTypes.Concatenation.Middle.create_bare
+    in
+    Type.OrderedTypes.Concatenation (Type.OrderedTypes.Concatenation.create middle)
   in
   assert_false
     (less_or_equal

--- a/analysis/typeCheck.ml
+++ b/analysis/typeCheck.ml
@@ -525,14 +525,8 @@ module State (Context : Context) = struct
     | Some [] ->
         parent_type
     | Some variables ->
-        let variables =
-          List.map variables ~f:(function
-              | Unary variable -> Type.Parameter.Single (Type.Variable variable)
-              | ListVariadic variadic -> Group (Type.Variable.Variadic.List.self_reference variadic)
-              | ParameterVariadic parameters ->
-                  CallableParameters (Type.Variable.Variadic.Parameters.self_reference parameters))
-        in
-        Type.parametric parent_name variables
+        let variables = List.map variables ~f:Type.Variable.to_parameter in
+        Type.Parametric { name = parent_name; parameters = variables }
     | exception _ -> parent_type
 
 

--- a/analysis/typeOrder.ml
+++ b/analysis/typeOrder.ml
@@ -209,8 +209,8 @@ module OrderImplementation = struct
                 let variables = variables target in
                 let join_parameters (left, right, variable) =
                   match left, right, variable with
-                  | Type.Parameter.Group _, _, _
-                  | _, Type.Parameter.Group _, _
+                  | Type.Parameter.VariadicExpression _, _, _
+                  | _, Type.Parameter.VariadicExpression _, _
                   | _, _, Type.Variable.ListVariadic _
                   | CallableParameters _, _, _
                   | _, CallableParameters _, _

--- a/analysis/unannotatedGlobalEnvironment.ml
+++ b/analysis/unannotatedGlobalEnvironment.ml
@@ -645,7 +645,7 @@ let missing_builtin_classes, missing_typing_classes, missing_typing_extensions_c
   let single_unary_generic =
     [Type.parametric "typing.Generic" [Single (Variable (Type.Variable.Unary.create "typing._T"))]]
   in
-  let catch_all_generic = [Type.parametric "typing.Generic" [Group Any]] in
+  let catch_all_generic = [Type.parametric "typing.Generic" [VariadicExpression (Group Any)]] in
   let callable_body =
     [
       Statement.Assign

--- a/pyre_extensions/__init__.py
+++ b/pyre_extensions/__init__.py
@@ -99,6 +99,7 @@ def ListVariadic(name) -> object:
 _A = TypeVar("_A", bound=int)
 _B = TypeVar("_B", bound=int)
 _Ts = ListVariadic("_Ts")
+_Ts1 = ListVariadic("_Ts1")
 
 
 class Add(Generic[_A, _B], int):
@@ -118,4 +119,8 @@ class Length(Generic[_Ts], int):
 
 
 class Product(Generic[_Ts], int):
+    pass
+
+
+class Broadcast(Generic[_Ts, _Ts1], object):
     pass

--- a/test/test.ml
+++ b/test/test.ml
@@ -1396,8 +1396,10 @@ let typeshed_stubs ?(include_helper_builtins = true) () =
         class Multiply(Generic[_A, _B], int): pass
         class Divide(Generic[_A, _B], int): pass
         _Ts = ListVariadic("_Ts")
+        _Ts1 = ListVariadic("_Ts1")
         class Length(Generic[_Ts], int): pass
         class Product(Generic[_Ts], int): pass
+        class Broadcast(Generic[_Ts, _Ts1], object): pass
         |}
     );
     ( "pyre_extensions/type_variable_operators.pyi",


### PR DESCRIPTION
Summary:
This diff adds support for the Broadcast operator on variadics. Some aspects of how Pyre deals with variadics are redesign in order to bring support for type operators on variadics.

# Motivation
Broadcast refers to the term used by Numpy to express how some operators between n-dimensional matrices behave when matrices do not have the same dimensions, but they are compatible under some "broadcasting semantics". This concept, known from Numpy (https://numpy.org/doc/stable/user/basics.broadcasting.html), has been borrowed by other libraries like PyTorch (https://pytorch.org/docs/stable/notes/broadcasting.html), Tensorflow (https://www.tensorflow.org/xla/broadcasting).

Currently, we are working on multiple innovations to Python's type system in order to offer better support for typing numerical libraries, in particular for typing tensor libraries and how operators manipulate dimensions. To be able to track dimensions of tensors on the numerous operators that rely on broadcasting a custom type operator is needed.

Although the use case of such type operators would be mostly limited to numerical libraries, we believe that it is justified considering the relevance of Numpy, Pytorch and Tensorflow in Python's ecosystem.

## PyTorch operators
In the case of Pytorch, some of the operators that Broadcast would allow to type are:
- matmul
- add
- sub
- div
- lerp
- masked_fill
- gt / lt / le / eq

# Semantics
A complete explanation of broadcasting semantics can be found here: https://numpy.org/doc/stable/user/basics.broadcasting.html

```
Example:
A      :  8 x 1 x 6 x 1
B      :      7 x 1 x 5
-----------------------
Result :  8 x 7 x 6 x 5
```

# Implementation Background
Pyre's implementation of variadics is based on the assumption that a variadic can be:
- List of types
- Any variadic
- ListVariadic variable
- Map on ListVariadic
- Concatenation of ListVariadic (w or w/ Map) and types.

What in Pyre is represented as:
```
type 'a record =
| Concrete of 'a list
| Any
| Concatenation of ('a Middle.t, 'a) RecordConcatenate.t
```

While the first two are obvious, Concatenation is a bit more complex. Concatenation is used to represent the rest cases, even if the user code does not use the concatenate operator. A closer look on how a Concatenation type looks like is the following:

```
Concatenation {middle={variable; mappers=[]}; wrapping={head=[];tail=[]}}
```

An example how a complex expression would be encode follows:

```
Concatenate[A,Map[Map[Ts,str],int],float,B]
->
Concatenation {
	middle = {
		variable = Ts;
		mappers = [str; int]
	};
	wrapping = {
		head = [A];
		tail = [float; B]
	}
}
```

Even if the code does not contain any Concatenate operator, the same variant will be used but it can be easily identified it corresponds to a concatenation or to a single ListVariadic checking if wrapping is empty.

Since there are no type operators on variadics beyond Map, the internals of variadics take advantage of that by representing a Map on a variadic as a list of the types that it is mapped to. However, such design does not allow to support arbitrary operators on variadics.

A variadic operator is an operator that takes one or more variadics and returns a variadic. Similarly they can be used wherever a variadic is expected. For example:
- `Vec[Ts]`
- `Vec[VariadicOperator[Ts,Ts]]`
- `Vec[Cat[Ts,A]]`
- `Vec[Cat[VariadicOperator[Ts,Ts],A]`

Due to the limits of the current design, not even Map and Concatenate offer the flexibility that is expected from a variadic operator (e.g. `Vec[Cat[int,Cat[Ts,int]]]`). Similarly, the Broadcasting operator could not be represented following the same approach since it takes 2 variadics (unlike Concatenate or Map) and it should be accepted both inside and outside of a concatenation.

# Variadic Expressions

Given the limitations of the current design of variadics, an extension is needed in order to allow to support variadic expressions, which means arbitrary combinations of variadic operators.

The main changes that are required for supporting variadic expressions are the following:
- Parametrics should accept variadic_expressions rather than a variadic
-> Extend Parametric variant to accept variadic_expression
- Inside a Concatenation there can be a variadic_expression or a ListVariadic variable
-> Extend Middle.variable to accept variadic_expression
- Any ListVariadic should be repleceable by a variadic_expression
 -> Redefine domain of ListVariadic to be variadic_expression rather than OrderedTypes.record

Those changes should make following possible:
- `Vec[Ts]`
- `Vec[BC[Ts,Ts]]`
- `Vec[Cat[Ts,A]]`
- `Vec[Cat[BC[Ts,Ts],A]`

## Coexisting VariadicExpression with Concat & Map
While this diff only takes advantage of the new VariadicExpression framework to support Broadcast, it could serve as a solid foundation to reimplement Concat & Map on top of it, so that these operator do not need an special treatment anymore, simplifying the overall logic. However, at this point Concat & Map will not be modified, what in some cases leads some extra verbosity and recursivity.

# Alternatives
## Extend Middle.t as for Map
In order to simplify the inclusion of Broadcast, it could also be considered to support it as Map is supported. Although that would not build a foundation for future variadic operators, given that currently there are no other variadics planned it may be not needed.

Unfortunately, the idea that worked for Map does not work for Broadcast. The reason why Map works is that it takes only one Variadic, rather than 2 in Broadcast, so it is implicit the way how Map is nested, while Broadcast needs a way of specifying 2 variadics.

## Support Broadcast only outside Concatenate
Supporting Broadcast with the constraint that it cannot appear inside a Concatenate or Map would greatly simplify the design. It would not require to redefine the domain of ListVariadic, and hence neither the logic related with variables and bounds in other files.
Although the simplicity of the change can be very appealing, unfortunately the value that such feature would bring is very low. Even if the programmer doesn't write directly a Broadcast inside Concatenate, it can easily happen that a ListVariadic inside a concatenation the variable is replaced by a Broadcast, what could not be supported.

# Review advice
Although the diff is long, a large amount of the changes simply correspond to the introduction of new types. One example are all tests, where `Group ()` is replaced by `VariadicExpression (Group ())`. Another example is the definition of the interface of the modules RecordConcatenate and Middle inside `type.ml` to allow mutual recursion.

Also, you may find a couple of TODO's that will be simple to implement but I preferred to wait to get feedback on the rest of the diff, since the TODO's do not affect much the functionality.

Differential Revision: D23371105

