### PR TITLE
Rely on typeshed and search path from virtual environment when none specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 /.pyre
 yarn-error.log
+.watchmanconfig
 
 _build
 .merlin


### PR DESCRIPTION
Test plan:
```
(pyre) [pyre-check]$ python -m client.pyre check
```
with configuration from D25797897. This results in 54 errors right now.