### PR TITLE
[RFC] Deduplicate error messages from configuration

### DIFF
--- a/client/commands/v2/tests/validate_models_test.py
+++ b/client/commands/v2/tests/validate_models_test.py
@@ -37,7 +37,7 @@ class ValidateModelsTest(testslide.TestCase):
         assert_parsed({"response": {"errors": []}}, expected=[])
 
         with tempfile.TemporaryDirectory() as root:
-            root_path = Path(root)
+            root_path = Path(root).resolve()
             with setup.switch_working_directory(root_path):
                 assert_parsed(
                     {


### PR DESCRIPTION
Please advise on how this is supposed to be done. I'm assuming unfreezing a data-class will trigger people...

Test plan:
```
$ python -m client.pyre --typeshed ~/.venvs/new/lib/pyre_check/typeshed/ check
```
No longer displays duplicate error message about 