### PR TITLE
Check version against version specified in configuration.

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,5 +6,6 @@
   ],
   "source_directories": [
     "."
-  ]
+  ],
+  "version": "0.0.101610021393"
 }

--- a/client/pyre.py
+++ b/client/pyre.py
@@ -111,6 +111,7 @@ def run_pyre_command(
     exit_code = ExitCode.FAILURE
     try:
         configuration_module.check_nested_local_configuration(configuration)
+        configuration_module.check_open_source_version(configuration)
         log.start_logging_to_directory(noninteractive, configuration.log_directory)
         LOG.debug(f"Running cli command `{' '.join(sys.argv)}`...")
         exit_code = command.run().exit_code()


### PR DESCRIPTION
More trigger warnings! Same as before: please let me know how to properly do this...

Test plan:
```
[pyre-check]$ python -m client.pyre --typeshed ~/.venvs/new/lib/pyre_check/typeshed/ check
ƛ Using virtual environment site-packages in search path...
ƛ Your running version does not match the configured version for this
project (running 0.0.101610021394, expected 0.0.101610021393).
...
```