### PR TITLE
[Pysa] Set up initial deliberately vulnerable app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 __pycache__
-/.pyre
+.pyre/
+venv/
 yarn-error.log
 .watchmanconfig
 

--- a/documentation/deliberately_vulnerable_flask_app/README.md
+++ b/documentation/deliberately_vulnerable_flask_app/README.md
@@ -1,0 +1,8 @@
+# Overview
+This is a trivially vulnerable Flask application, meant as a playground for
+testing Pysa
+
+# Setup
+1. `pip install pyre-check-nightly`
+2. `pyre init`
+3. `pyre analyze --no-verify`

--- a/documentation/deliberately_vulnerable_flask_app/rce.py
+++ b/documentation/deliberately_vulnerable_flask_app/rce.py
@@ -1,0 +1,21 @@
+import subprocess
+
+from flask import Flask
+
+
+app = Flask(__name__)
+
+
+@app.route("/rce/<string:payload>")
+def definite_rce(payload: str) -> None:
+    subprocess.run(payload, shell=True)
+
+
+@app.route("/rce/<string:payload>")
+def potential_rce_1(payload: str) -> None:
+    subprocess.run(["echo", payload])
+
+
+@app.route("/rce/<int:payload>")
+def potential_rce_2(payload: int) -> None:
+    subprocess.run(f"echo {payload}", shell=True)

--- a/documentation/deliberately_vulnerable_flask_app/setup.sh
+++ b/documentation/deliberately_vulnerable_flask_app/setup.sh
@@ -1,0 +1,10 @@
+# Source this file to run it:
+# . ./setup.sh
+
+# This file should ONLY include standard setup steps which would be used by a
+# real Flask project. Do not add anything Pysa/Pyre specific.
+
+python3 -m venv venv
+. venv/bin/activate
+pip install Flask
+rm ../.pyre_configuration


### PR DESCRIPTION
# Summary
This creates a simple web app that is deliberately vulnerable and meant to look like a normal web app which has never had a Pysa integration before. This will be our test bed for ensuring that getting up and running with Pysa from 0 is easy.

# Test Plan:
Set up app
```
gbleaney-mbp:deliberately_vulnerable_flask_app gbleaney$ . ./setup.sh
Requirement already satisfied: Flask in ./venv/lib/python3.7/site-packages (1.1.2)
Requirement already satisfied: Jinja2>=2.10.1 in ./venv/lib/python3.7/site-packages (from Flask) (2.11.2)
...
```
Initialize config
```
(venv) gbleaney-mbp:deliberately_vulnerable_flask_app gbleaney$ pyre init
ƛ Also initialize watchman in the current directory? [Y/n] n
ƛ Which directory should pyre be initialized in? (Default: `.`):
ƛ Successfully initialized pyre! You can view the configuration at `/Users/gbleaney/pyre-check/deliberately_vulnerable_flask_app/.pyre_configuration`.
(venv) gbleaney-mbp:deliberately_vulnerable_flask_app gbleaney$ cat .pyre_configuration
{
  "binary": "/Users/gbleaney/pyre-check/deliberately_vulnerable_flask_app/venv/bin/pyre.bin",
  "source_directories": [
    "."
  ],
  "taint_models_path": "/Users/gbleaney/pyre-check/deliberately_vulnerable_flask_app/venv/lib",
  "typeshed": "/Users/gbleaney/pyre-check/deliberately_vulnerable_flask_app/venv/lib/pyre_check/typeshed"
}
(venv) gbleaney-mbp:deliberately_vulnerable_flask_app gbleaney$
```
Run pysa
```
(venv) gbleaney-mbp:deliberately_vulnerable_flask_app gbleaney$ pyre analyze --no-verify
ƛ Using virtual environment site-packages in search path...
ƛ Found 224 model verification errors!
ƛ /Users/gbleaney/pyre-check/deliberately_vulnerable_flask_app/venv/lib/pyre_check/taint/django_sources_sinks.pysa:132: `django.contrib.sessions.backends.base.SessionBase._session_key` is not part of the environment!
ƛ /Users/gbleaney/pyre-check/deliberately_vulnerable_flask_app/venv/lib/pyre_check/taint/django_sources_sinks.pysa:131: `django.contrib.sessions.backends.base.SessionBase.session_key` is not part of the environment!
...
[
  {
    "line": 21,
    "column": 19,
    "stop_line": 21,
    "stop_column": 36,
    "path": "rce.py",
    "code": 5001,
    "name": "Possible shell injection",
    "description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "long_description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "concise_description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "inference": null,
    "define": "rce.potential_rce_2"
  },
  {
    "line": 16,
    "column": 19,
    "stop_line": 16,
    "stop_column": 36,
    "path": "rce.py",
    "code": 5001,
    "name": "Possible shell injection",
    "description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "long_description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "concise_description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "inference": null,
    "define": "rce.potential_rce_1"
  },
  {
    "line": 11,
    "column": 19,
    "stop_line": 11,
    "stop_column": 26,
    "path": "rce.py",
    "code": 5001,
    "name": "Possible shell injection",
    "description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "long_description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "concise_description":
      "Possible shell injection [5001]: Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)",
    "inference": null,
    "define": "rce.definite_rce"
  },
  {
    "line": 111,
    "column": 16,
    "stop_line": 111,
    "stop_column": 22,
    "path": "venv/lib/python3.7/site-packages/flask_graphql/graphqlview.py",
    "code": 5008,
    "name": "XSS",
    "description":
      "XSS [5008]: Data from [UserControlled] source(s) may reach [XSS] sink(s)",
    "long_description":
      "XSS [5008]: Data from [UserControlled] source(s) may reach [XSS] sink(s)",
    "concise_description":
      "XSS [5008]: Data from [UserControlled] source(s) may reach [XSS] sink(s)",
    "inference": null,
    "define": "flask_graphql.graphqlview.GraphQLView.dispatch_request"
  }
]
(venv) gbleaney-mbp:deliberately_vulnerable_flask_app gbleaney$
```
Issues were caught!