### PR TITLE
Fix the "--upgrade" flag typo

### DIFF
--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -69,7 +69,7 @@ A brief summary to get this running on *Ubuntu* please follow:
 ```bash
 $ sudo apt install python3-venv build-essential python3-dev libpython3-dev
 $ python3 -m venv /tmp/tp
-$ /tmp/tp/bin/pip install --update pip setuptools wheel
+$ /tmp/tp/bin/pip install --upgrade pip setuptools wheel
 $ /tmp/tp/bin/pip install pyre-check
 $ source /tmp/tp/bin/activate
 $ cd /mnt/c/path/to/repo


### PR DESCRIPTION
Simple typo.

```
$pip install --update pip setuptools wheel

Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --update
$ pip install --upgrade pip setuptools wheel
Collecting pip
  Downloading pip-21.0-py3-none-any.whl (1.5 MB)
     |████████████████████████████████| 1.5 MB 2.9 MB/s 
Collecting setuptools
  Downloading setuptools-52.0.0-py3-none-any.whl (784 kB)
     |████████████████████████████████| 784 kB 2.0 MB/s 
Requirement already up-to-date: wheel in /mnt/c/Users/Mike/Desktop/Repos/env39_wsl/lib/python3.9/site-packages (0.36.2)
Installing collected packages: pip, setuptools
  Attempting uninstall: pip
    Found existing installation: pip 20.2.3
    Uninstalling pip-20.2.3:
      Successfully uninstalled pip-20.2.3
  Attempting uninstall: setuptools
    Found existing installation: setuptools 49.2.1
    Uninstalling setuptools-49.2.1:
      Successfully uninstalled setuptools-49.2.1
Successfully installed pip-21.0 setuptools-52.0.0
```