### PR TITLE
Fix broken import caused by source code reorgainzation

### DIFF
--- a/documentation/pysa_tutorial/exercise5/generate_models.py
+++ b/documentation/pysa_tutorial/exercise5/generate_models.py
@@ -13,7 +13,7 @@ from urls import UrlPattern
 # Make sure we're able to import dependencies in 'pyre-check' repo, since they
 # are not currently in the PyPI package for pyre-check
 current_file = Path(__file__).absolute()
-sys.path.append(str(current_file.parents[3]))
+sys.path.append(str(current_file.parents[4]))
 
 # Work around '-' in the name of 'pyre-check'
 generate_taint_models = importlib.import_module(


### PR DESCRIPTION
### Summary
This fixes the bug reported in #376. Basically, when we re-organized our source code to put the tutorial in the documentation folder, this relative import broke. Bumping the number fixes the relative import.

### Test Plan
Before:
```
gbleaney-mbp:exercise5 gbleaney$ python3 generate_models.py --output-directory .
Traceback (most recent call last):
  File "generate_models.py", line 20, in <module>
    "pyre-check.tools.generate_taint_models"
  File "/opt/homebrew/Cellar/python37/3.7.5_3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'pyre-check'
gbleaney-mbp:exercise5 gbleaney$
```

After:
```
(tutorial) gbleaney-mbp:exercise5 gbleaney$ python3 generate_models.py --output-directory .
2021-02-02 17:57:49 INFO Computing models for `django_path_params`
2021-02-02 17:57:49 INFO Getting all URLs from `urls`
2021-02-02 17:57:49 INFO Computed models for `django_path_params` in 0.000 seconds.
{"number of generated models": 1}
(tutorial) gbleaney-mbp:exercise5 gbleaney$
```