### PR TITLE
updated Contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ The way you can get around this is by setting up environment variables. If set, 
 
 Example `.bashrc`/`.bash_profile`:
 ```bash
-export PYRE_BINARY=/path/to/pyre-check/_build/default/main.exe
+export PYRE_BINARY=/path/to/pyre-check/source/_build/default/main.exe
 ```
 
 If you're working with a `PYRE_BINARY` and are frequently re-compiling Pyre, you should avoid using the Pyre server, as the server will not stop when you re-compile Pyre. You should instead run `pyre check` to create a one-off run.


### PR DESCRIPTION
Upon building project from source, `_build` is  dumped in `pyre-check/source` and not in the root directory itself. Hence, example export command for `PYRE_BINARY` could be updated.