### PR TITLE
Only require `dataclasses` for python3.6

### DIFF
--- a/scripts/pypi/build_pypi_package.py
+++ b/scripts/pypi/build_pypi_package.py
@@ -25,7 +25,7 @@ MODULE_NAME = "pyre_check"
 RUNTIME_DEPENDENCIES = [
     "async-generator",
     "click",
-    "dataclasses",
+    "dataclasses;python_version=='3.6'",
     "dataclasses-json",
     "libcst>=0.3.6",
     "psutil",


### PR DESCRIPTION
`dataclasses` is included with the stdlib for python>=3.7, so it should only need to be installed for python3.6 environments.

`dataclasses==0.6` is technically compatible with python3.7, so it is being installed when installing this package, but that clashes with other projects (namely `Black`, which requires `dataclasses>=0.8` in a python3.6 environment, and uses the built-in `dataclasses` in python3.7+ environments). To avoid jumping through hoops specifying these dependencies down the chain with pip, this package should avoid installing `dataclasses` outside of a python3.6 environment.