### PR TITLE
Updated installation.md

### DIFF
--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -47,7 +47,7 @@ $ cd pyre-check
 $ ./scripts/setup.sh --local
 ```
 
-This will generate a `Makefile` in your checkout directory. You can subsequently build and test
+This will generate a `Makefile` in the `source` directory. You can subsequently build and test
 `pyre` with
 
 ```bash


### PR DESCRIPTION
MakeFile is dumped in the source directory now, instead of the checkout (root) directory.