### PR TITLE
Updated guidelines for building Pyre from source

### DIFF
--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -62,7 +62,7 @@ $ cd /path/to/pyre-check
 $ pip install -r requirements.txt
 $ ./scripts/run-python-tests.sh
 ```
-When installing and running `pyre` from PyPi, the entry point to the executable is actually `client/pyre.py`. To be able to run this file from anywhere, add the `pyre-check` directory to `PYTHONPATH` and subsequently assign `client.pyre` an alias to invoke the binary from anywhere
+When installing and running `pyre` from PyPi, the entry point to the executable is actually `client/pyre.py`. To be able to run this file from anywhere, add the `pyre-check` directory to `PYTHONPATH` and subsequently assign `pyre` and an alias for `client.pyre`.
 
 ```bash
 $ echo "alias pyre='PYTHONPATH=\"/path/to/pyre-check:\$PYTHONPATH\" python -m client.pyre'" >> ~/.bashrc

--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -65,8 +65,7 @@ $ ./scripts/run-python-tests.sh
 When installing and running `pyre` from PyPi, the entry point to the executable is actually `client/pyre.py`. To be able to run this file from anywhere, add the `pyre-check` directory to `PYTHONPATH` and subsequently assign `client.pyre` an alias to invoke the binary from anywhere
 
 ```bash
-$ echo "export PYTHONPATH=/path/to/pyre-check" >> ~/.bashrc
-$ echo "alias pyre='python -m client.pyre'" >> ~/.bashrc
+$ echo "alias pyre='PYTHONPATH=\"/path/to/pyre-check:\$PYTHONPATH\" python -m client.pyre'" >> ~/.bashrc
 $ source ~/.bashrc
 ```
 You should be able to open a new shell and run `pyre -h` now, confirming `pyre` was set-up correctly. Any changes made to the Pyre Python client code should be immediately observable the next time you invoke `pyre`

--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -34,7 +34,7 @@ $ opam switch 4.10.2
 
 This will compile the compiler from scratch and is likely going to take some time on your system.
 
-### Building for OCaml changes
+### Building OCaml changes
 With a working OCaml, you can clone the source from [GitHub](https://github.com/facebook/pyre-check) with
 ```bash
 $ git clone https://github.com/facebook/pyre-check
@@ -54,20 +54,22 @@ This will generate a `Makefile` in your checkout directory. You can subsequently
 $ make
 $ make test
 ```
-### Building for Pyre changes
+### Testing changes to the Python Client
 In a virtualenv, install dependencies with `requirements.txt` and run python tests to make sure everything is set up correctly
 
 ```bash
+$ cd /path/to/pyre-check
 $ pip install -r requirements.txt
 $ ./scripts/run-python-tests.sh
 ```
-Since `pyre` is expected to run from the root directory using the `client/pyre.py` wrapper, we can add this directory to `PYTHONPATH` and subsequently assign it an alias to invoke the binary from anywhere
+When installing and running `pyre` from PyPi, the entry point to the executable is actually `client/pyre.py`. To be able to run this file from anywhere, add the `pyre-check` directory to `PYTHONPATH` and subsequently assign `client.pyre` an alias to invoke the binary from anywhere
 
 ```bash
 $ echo "export PYTHONPATH=/path/to/pyre-check" >> ~/.bashrc
 $ echo "alias pyre='python -m client.pyre'" >> ~/.bashrc
+$ source ~/.bashrc
 ```
-You should be able to open a new shell and run `pyre -h` now, confirming `pyre` was set-up correctly.
+You should be able to open a new shell and run `pyre -h` now, confirming `pyre` was set-up correctly. Any changes made to the Pyre Python client code should be immediately observable the next time you invoke `pyre`
 
 ## Windows Subsystem for Linux (WSL) Install
 

--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -34,7 +34,7 @@ $ opam switch 4.10.2
 
 This will compile the compiler from scratch and is likely going to take some time on your system.
 
-### Getting the Source
+### Building for OCaml changes
 With a working OCaml, you can clone the source from [GitHub](https://github.com/facebook/pyre-check) with
 ```bash
 $ git clone https://github.com/facebook/pyre-check
@@ -54,6 +54,20 @@ This will generate a `Makefile` in your checkout directory. You can subsequently
 $ make
 $ make test
 ```
+### Building for Pyre changes
+In a virtualenv, install dependencies with `requirements.txt` and run python tests to make sure everything is set up correctly
+
+```bash
+$ pip install -r requirements.txt
+$ ./scripts/run-python-tests.sh
+```
+Since `pyre` is expected to run from the root directory using the `client/pyre.py` wrapper, we can add this directory to `PYTHONPATH` and subsequently assign it an alias to invoke the binary from anywhere
+
+```bash
+$ echo "export PYTHONPATH=/path/to/pyre-check" >> ~/.bashrc
+$ echo "alias pyre='python -m client.pyre'" >> ~/.bashrc
+```
+You should be able to open a new shell and run `pyre -h` now, confirming `pyre` was set-up correctly.
 
 ## Windows Subsystem for Linux (WSL) Install
 


### PR DESCRIPTION
There are some missing steps in the docs for building and testing pyre from source. As per my understanding, the internal build and testing system for Pyre is different from the one in open source.

The changes, as discussed with @gbleaney, aim to simplify contributing to Pyre by documenting the extra steps/ possible issues contributors might face while setting up the development environment from source.

The reason behind each of the changes are as follows:

1. As I understand, `run-python-tests.sh` is a replacement for the older `make python_tests` command. I have noticed that running the script directly gives some "missing modules" errors, which are resolved by  installing the dependencies via `requirements.txt`. Hence, documenting this step might be a good idea.
2. After completing all the installation steps, the only way to run pyre is via `client/pyre.py` wrapper from the root directory. However, trying to run it directly gives `relative import` errors, which are resolved only by invoking it as a module. This makes it a frustrating task to call Pyre from anywhere other than the root directory. Adding the root to `PYTHONPATH` and making an alias is a workaround to that.