### PR TITLE
Renamed Server for Pyre to PyreServer

### DIFF
--- a/client/commands/v2/persistent.py
+++ b/client/commands/v2/persistent.py
@@ -237,7 +237,7 @@ class ServerState:
     )
 
 
-class Server:
+class PyreServer:
     # I/O Channels
     input_channel: connection.TextReader
     output_channel: connection.TextWriter
@@ -773,7 +773,7 @@ async def run_persistent(
             client_capabilities = initialize_result.client_capabilities
             LOG.debug(f"Client capabilities: {client_capabilities}")
             initial_server_state = ServerState()
-            server = Server(
+            server = PyreServer(
                 input_channel=stdin,
                 output_channel=stdout,
                 client_capabilities=client_capabilities,

--- a/client/commands/v2/tests/persistent_test.py
+++ b/client/commands/v2/tests/persistent_test.py
@@ -29,7 +29,7 @@ from ..persistent import (
     InitializationSuccess,
     InitializationFailure,
     InitializationExit,
-    Server,
+    PyreServer,
     ServerState,
     parse_subscription_response,
     SubscriptionResponse,
@@ -212,7 +212,7 @@ class PersistentTest(testslide.TestCase):
     @setup.async_test
     async def test_open_close(self) -> None:
         server_state = ServerState()
-        server = Server(
+        server = PyreServer(
             input_channel=create_memory_text_reader(""),
             output_channel=create_memory_text_writer(),
             client_capabilities=lsp.ClientCapabilities(),
@@ -276,7 +276,7 @@ class PersistentTest(testslide.TestCase):
         )
         bytes_writer = MemoryBytesWriter()
         fake_task_manager = BackgroundTaskManager(WaitForeverBackgroundTask())
-        server = Server(
+        server = PyreServer(
             input_channel=create_memory_text_reader(""),
             output_channel=TextWriter(bytes_writer),
             client_capabilities=lsp.ClientCapabilities(),
@@ -314,7 +314,7 @@ class PersistentTest(testslide.TestCase):
     @setup.async_test
     async def test_open_triggers_pyre_restart(self) -> None:
         fake_task_manager = BackgroundTaskManager(WaitForeverBackgroundTask())
-        server = Server(
+        server = PyreServer(
             input_channel=create_memory_text_reader(""),
             output_channel=create_memory_text_writer(),
             client_capabilities=lsp.ClientCapabilities(),
@@ -340,7 +340,7 @@ class PersistentTest(testslide.TestCase):
     @setup.async_test
     async def test_open_triggers_pyre_restart__limit_reached(self) -> None:
         fake_task_manager = BackgroundTaskManager(WaitForeverBackgroundTask())
-        server = Server(
+        server = PyreServer(
             input_channel=create_memory_text_reader(""),
             output_channel=create_memory_text_writer(),
             client_capabilities=lsp.ClientCapabilities(),
@@ -369,7 +369,7 @@ class PersistentTest(testslide.TestCase):
     async def test_save_triggers_pyre_restart(self) -> None:
         test_path = Path("/foo.py")
         fake_task_manager = BackgroundTaskManager(WaitForeverBackgroundTask())
-        server = Server(
+        server = PyreServer(
             input_channel=create_memory_text_reader(""),
             output_channel=create_memory_text_writer(),
             client_capabilities=lsp.ClientCapabilities(),
@@ -392,7 +392,7 @@ class PersistentTest(testslide.TestCase):
     async def test_save_triggers_pyre_restart__limit_reached(self) -> None:
         test_path = Path("/foo.py")
         fake_task_manager = BackgroundTaskManager(WaitForeverBackgroundTask())
-        server = Server(
+        server = PyreServer(
             input_channel=create_memory_text_reader(""),
             output_channel=create_memory_text_writer(),
             client_capabilities=lsp.ClientCapabilities(),


### PR DESCRIPTION
Renaming the language server for Pyre to PyreServer for less ambiguity before introducing PysaServer. Pyre and Pysa will have different language servers, because they're going to handle different files, and be used by different users.

