### PR TITLE
Delete duplicate import of `version`

### DIFF
--- a/client/commands/v2/persistent.py
+++ b/client/commands/v2/persistent.py
@@ -23,7 +23,6 @@ from ... import (
     commands,
     configuration as configuration_module,
     statistics,
-    version,
 )
 from . import (
     language_server_protocol as lsp,


### PR DESCRIPTION
Noticed a small issue with `version` being imported twice here. I deleted the second import and left the one on line 21.