### PR TITLE
Added a new command for starting a pysa language server

### DIFF
--- a/client/pyre.py
+++ b/client/pyre.py
@@ -886,45 +886,33 @@ def pysa_language_server(context: click.Context, no_watchman: bool) -> int:
     configuration = configuration_module.create_configuration(
         command_argument, Path(".")
     )
-    if configuration.use_command_v2:
-        log.start_logging_to_directory(
-            # Always log to file regardless of whether `-n` is given
-            noninteractive=False,
-            log_directory=configuration.log_directory,
-        )
-        return v2.pysa_server.run(
-            configuration,
-            command_arguments.StartArguments(
-                changed_files_path=command_argument.changed_files_path,
-                debug=command_argument.debug,
-                enable_memory_profiling=command_argument.enable_memory_profiling,
-                enable_profiling=command_argument.enable_profiling,
-                load_initial_state_from=command_argument.load_initial_state_from,
-                log_identifier=command_argument.log_identifier,
-                logging_sections=command_argument.logging_sections,
-                no_saved_state=command_argument.no_saved_state,
-                no_watchman=no_watchman,
-                noninteractive=command_argument.noninteractive,
-                save_initial_state_to=command_argument.save_initial_state_to,
-                saved_state_project=command_argument.saved_state_project,
-                sequential=command_argument.sequential,
-                show_error_traces=command_argument.show_error_traces,
-                store_type_check_resolution=False,
-                terminal=False,
-                wait_on_initialization=True,
-            ),
-        )
-    else:
-        return run_pyre_command(
-            commands.Persistent(
-                command_argument,
-                original_directory=os.getcwd(),
-                configuration=configuration,
-                no_watchman=no_watchman,
-            ),
-            configuration,
-            True,
-        )
+    log.start_logging_to_directory(
+        # Always log to file regardless of whether `-n` is given
+        noninteractive=False,
+        log_directory=configuration.log_directory,
+    )
+    return v2.pysa_server.run(
+        configuration,
+        command_arguments.StartArguments(
+            changed_files_path=command_argument.changed_files_path,
+            debug=command_argument.debug,
+            enable_memory_profiling=command_argument.enable_memory_profiling,
+            enable_profiling=command_argument.enable_profiling,
+            load_initial_state_from=command_argument.load_initial_state_from,
+            log_identifier=command_argument.log_identifier,
+            logging_sections=command_argument.logging_sections,
+            no_saved_state=command_argument.no_saved_state,
+            no_watchman=no_watchman,
+            noninteractive=command_argument.noninteractive,
+            save_initial_state_to=command_argument.save_initial_state_to,
+            saved_state_project=command_argument.saved_state_project,
+            sequential=command_argument.sequential,
+            show_error_traces=command_argument.show_error_traces,
+            store_type_check_resolution=False,
+            terminal=False,
+            wait_on_initialization=True,
+        ),
+    )
 
 
 @pyre.command()

--- a/client/pyre.py
+++ b/client/pyre.py
@@ -874,6 +874,60 @@ def persistent(context: click.Context, no_watchman: bool) -> int:
 
 
 @pyre.command()
+@click.option("--no-watchman", is_flag=True, default=False, hidden=True)
+@click.pass_context
+def pysa_language_server(context: click.Context, no_watchman: bool) -> int:
+    """
+    Entry point for IDE integration to Pysa. Communicates with a Pysa server using
+    the Language Server Protocol, accepts input from stdin and writing diagnostics
+    and responses from the Pysa server to stdout.
+    """
+    command_argument: command_arguments.CommandArguments = context.obj["arguments"]
+    configuration = configuration_module.create_configuration(
+        command_argument, Path(".")
+    )
+    if configuration.use_command_v2:
+        log.start_logging_to_directory(
+            # Always log to file regardless of whether `-n` is given
+            noninteractive=False,
+            log_directory=configuration.log_directory,
+        )
+        return v2.pysa_server.run(
+            configuration,
+            command_arguments.StartArguments(
+                changed_files_path=command_argument.changed_files_path,
+                debug=command_argument.debug,
+                enable_memory_profiling=command_argument.enable_memory_profiling,
+                enable_profiling=command_argument.enable_profiling,
+                load_initial_state_from=command_argument.load_initial_state_from,
+                log_identifier=command_argument.log_identifier,
+                logging_sections=command_argument.logging_sections,
+                no_saved_state=command_argument.no_saved_state,
+                no_watchman=no_watchman,
+                noninteractive=command_argument.noninteractive,
+                save_initial_state_to=command_argument.save_initial_state_to,
+                saved_state_project=command_argument.saved_state_project,
+                sequential=command_argument.sequential,
+                show_error_traces=command_argument.show_error_traces,
+                store_type_check_resolution=False,
+                terminal=False,
+                wait_on_initialization=True,
+            ),
+        )
+    else:
+        return run_pyre_command(
+            commands.Persistent(
+                command_argument,
+                original_directory=os.getcwd(),
+                configuration=configuration,
+                no_watchman=no_watchman,
+            ),
+            configuration,
+            True,
+        )
+
+
+@pyre.command()
 @click.option(
     "--profile-output",
     type=click.Choice([str(x) for x in commands.ProfileOutput]),

--- a/tools/ide_plugins/pysa-vscode/src/main.ts
+++ b/tools/ide_plugins/pysa-vscode/src/main.ts
@@ -35,7 +35,7 @@ export async function activate(_: vscode.ExtensionContext) {
 
     let serverOptions = {
         command: "pyre",
-        args: ["persistent"]
+        args: ["pysa-language-server"]
     };
     
     let clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This change would create a `pysa-language-server` to connect to Pysa's language server. How should we handle versioning of commands here? Pysa server was introduced in v2 folder, so should we assume that the command works in v2? 

The `stop` command seems to be generic for all running servers (it iterates through socket files) -- should there be additional command for stopping Pysa's server?