### PR TITLE
Added Docker image for building from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,10 @@ During analysis, each function will be processed into a control flow graph to re
 
 ### Getting Started
 - Install `opam` and run `opam switch install "4.10.2"`
-- run ` ./scripts/setup.sh`
+- Run ` ./scripts/setup.sh`
 - After the setup script runs successfully, you should be able to `cd` into `source` and run `make` to build the Pyre binary
 
+Alternatively, you can also set up using [the Docker image](https://pyre-check.org/docs/installation/#building-from-docker) to build from source.
 
 ### How do I test my OCaml changes against real code?
 When you run pyre on the command line, what runs under the hood is a shim which finds and runs a suitable pyre binary. This works well for production use, but isn't great for testing out your own build of Pyre.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM ocaml/opam:debian-10-ocaml-4.11
+
+LABEL maintainer="gracewgao"
+
+USER root
+
+# installs system dependencies
+RUN apt update && apt upgrade -y \
+    && apt install python3 python3-pip pkg-config libsqlite3-dev build-essential -y \
+    && opam switch create 4.10.2
+
+# creates symlink for Python 3
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# updates PATH variable for opam
+ENV PATH="/home/opam/.opam/4.10.2/bin:$PATH"
+
+# adds then installs Python dependencies
+ADD --chown=1000:1000 requirements.txt /home/opam/pyre-check/
+WORKDIR /home/opam/pyre-check
+RUN pip3 install -r requirements.txt
+
+# adds then unzips typeshed
+ADD --chown=1000:1000 stubs/typeshed /home/opam/pyre-check/stubs/typeshed
+WORKDIR /home/opam/pyre-check/stubs/typeshed
+RUN unzip typeshed.zip && chown -R 1000:1000 typeshed-master
+
+# adds then builds pyre-check
+ADD --chown=1000:1000 . /home/opam/pyre-check
+WORKDIR /home/opam/pyre-check
+RUN ./scripts/setup.sh --local
+WORKDIR /home/opam/pyre-check/source
+RUN make && make test
+
+# workaround to enable running local changes to pyre commands
+RUN echo '#!/bin/bash\n \
+    python -m client.pyre "$@" \n' >> /home/opam/pyre-check/scripts/pyre \
+    && chmod +x /home/opam/pyre-check/scripts/pyre
+
+# runs python tests
+WORKDIR /home/opam/pyre-check
+RUN ./scripts/run-python-tests.sh
+
+# updates environment variables to use pyre-check
+ENV PYRE_BINARY="/home/opam/pyre-check/source/_build/default/main.exe"
+ENV PYRE_TYPESHED="/home/opam/pyre-check/stubs/typeshed/typeshed-master"
+ENV PYTHONPATH="/home/opam/pyre-check:$PYTHONPATH"
+ENV PATH="/home/opam/pyre-check/scripts:$PATH"
+
+# switches to home directory and non-root user on launch
+USER 1000
+WORKDIR /home/opam/
+
+CMD /bin/bash

--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -86,6 +86,43 @@ $ echo 'PATH="/path/to/pyre-check/scripts:$PATH"' >> ~/.bashrc
 $ source ~/.bashrc
 ```
 
+## Building from Docker
+
+If you're having issues setting up or your OS is not yet supported, you can also use a Docker image. It runs [Debian GNU/Linux 10 (buster)](https://www.debian.org/) and builds pyre-check from source.
+
+Before starting, ensure that [Docker](https://docs.docker.com/get-docker/) is installed on your computer.
+
+1. Clone the pyre-check repository and navigate to the root directory.
+   ```bash
+   git clone https://github.com/facebook/pyre-check.git
+   cd pyre-check
+   ```
+
+2. Build the Docker image with the tag `pyre-check` (or another tag if you wish)
+   ```bash
+   docker build -t pyre-docker .
+   ```
+
+3. Run the new image in a new container `pyre-container` (or another name if you wish)
+   ```bash
+   docker run \
+   --name pyre-container \
+   -v /path/to/your/directory:/src \
+   -t -i \
+   pyre-check
+   ```
+   *Note: Launching the container will build and run all tests.*
+
+4. Inside the container, run any Pyre command now with `pyre`!
+
+   *Note: When initializing Pyre with `pyre init`, you may have to enter the following paths for the binary and typeshed:*
+   ```bash
+   ƛ No `pyre.bin` found, enter the path manually: /home/opam/pyre-check/source/_build/default/main.exe
+   ƛ Unable to locate typeshed, please enter its root: /home/opam/pyre-check/stubs/typeshed/typeshed-master
+   ```
+
+**For contributors:** Inside the Docker container, the added pyre-check directory is only editable by the root user. To contribute to Pyre, make edits in your local filesystem and rebuild the Docker by running Step 2, then running a new Docker container in Steps 3-4.
+
 ## Windows Subsystem for Linux (WSL) Install
 
 On *x86_64* Windows `pyre` can run via *Linux* using [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux).


### PR DESCRIPTION
Here's the Dockerfile and the associated documentation for building pyre-check from source within a Docker container. This setup has already been tested on my Apple M1, but let me know if there's anything else I should change/add!