### PR TITLE
fix(docs): corrects common typos in project documentation

### DIFF
--- a/documentation/pysa_tutorial/exercise4/README.md
+++ b/documentation/pysa_tutorial/exercise4/README.md
@@ -26,7 +26,7 @@ The [_Static Analysis Post Processor
 (SAPP)_](https://pyre-check.org/docs/static-analysis-post-processor.html) ships
 in a separate package from Pysa, which you should have already installed during
 the initial setup of this tutorial. For projects larger than the toy examples in
-these tutorials, SAPP is the prefered way to browse issues.
+these tutorials, SAPP is the preferred way to browse issues.
 
 ## Instructions
 

--- a/documentation/website/docs/configuration.md
+++ b/documentation/website/docs/configuration.md
@@ -7,7 +7,7 @@ sidebar_label: Configuration
 Pyre can be run without a configuration (see [Command Line Arguments](configuration#command-line-arguments)) but we do recommend that you create a configuration (see [Getting Started](getting-started)) and commit that to your version control system to make sure everyone working on your project is using the same settings.
 
 ## Configuration Files
-Pyre has two types of configurations: a *global* configuration covering the full project, and *local* configurations that apply to subdirectories of the project. In most cases you will only need a global configuration but local configurations can be useful if you are dealing with a big repository containing heterogenous projects.
+Pyre has two types of configurations: a *global* configuration covering the full project, and *local* configurations that apply to subdirectories of the project. In most cases you will only need a global configuration but local configurations can be useful if you are dealing with a big repository containing heterogeneous projects.
 
 ### The Global Configuration
 The global configuration is a `.pyre_configuration` file sitting at the root of your project. Running Pyre anywhere inside your project directory will use the settings in this global configuration. You can generate an initial configuration in your project directory with

--- a/documentation/website/docs/errors.md
+++ b/documentation/website/docs/errors.md
@@ -927,7 +927,7 @@ async def g() -> AsyncGenerator[int, None]:  # OK
 It is not always possible to address all errors immediately – some code is too dynamic and should be refactored, other times it's *just not the right time* to deal with a type error. We do encourage people to keep their type check results clean at all times and provide mechanisms to suppress errors that cannot be immediately fixed.
 
 ### Suppressing Individual Errors
-Pyre supports error suppression of individual errors with comments that can be placed on the line of the error or on the line preceeding the error.
+Pyre supports error suppression of individual errors with comments that can be placed on the line of the error or on the line preceding the error.
 
 - `# pyre-fixme` indicates there is an issue in the code that will be revisited later.
 - `# pyre-ignore` indicates there's an issue with the type checker or the code is too dynamic and we have decided to not fix this. If this is a Pyre bug, make sure you [open an issue](https://github.com/facebook/pyre/issues) on our tracker.

--- a/documentation/website/docs/gradual_typing.md
+++ b/documentation/website/docs/gradual_typing.md
@@ -35,7 +35,7 @@ While `Any` is a necessary escape hatch when annotating large codebases over tim
 
 - run on all functions, whether they are annotated or not,
 - error on functions, globals, or attributes that are missing annotations,
-- and error on annotations containing `Any` (with some exceptions to accomodate for common patterns).
+- and error on annotations containing `Any` (with some exceptions to accommodate for common patterns).
 
 In our previous example,
 ```python

--- a/documentation/website/docs/pysa_false_negatives.md
+++ b/documentation/website/docs/pysa_false_negatives.md
@@ -13,7 +13,7 @@ source to a sink, but Pysa fails to catch it.
 
 Pysa relies on type information from Pyre to identify sources and sinks, and to
 build the call graph needed to follow the propagation of taint between the two.
-Just becasue type information is available *somewhere* in the code, does not
+Just because type information is available *somewhere* in the code, does not
 mean Pyre will know the type of an object in the exact place where Pysa needs
 it. See the documentation on [Coverage Increasing
 Strategies](pysa_increasing_coverage.md) for tips on how to increase type

--- a/documentation/website/docs/pysa_features.md
+++ b/documentation/website/docs/pysa_features.md
@@ -230,7 +230,7 @@ if `always-type:scalar` is present, `type:scalar` will not be present.
 ### `broadening` Feature
 
 The `broadening` feature is automatically added whenever Pysa makes an
-approximation about a taint flow. This is also refered as "taint collapsing"
+approximation about a taint flow. This is also referred as "taint collapsing"
 because the taint is internally represented as a tree structure where edges are
 attributes or indexes. Collapsing usually leads to tainting a whole object
 instead of a single attribute of that object.
@@ -263,7 +263,7 @@ sink(d) # too many indexes, the whole `d` variable becomes tainted.
 The `tito-broadening` feature is added when an object with tainted attributes is
 propagated through a function to its return value. For correctness reasons, Pysa
 makes the approximation that the whole returned object is tainted. This is
-refered as "Taint-In-Taint-Out collapsing".
+referred as "Taint-In-Taint-Out collapsing".
 
 ```python
 def identity(x):

--- a/documentation/website/docs/pysa_implementation_details.md
+++ b/documentation/website/docs/pysa_implementation_details.md
@@ -151,7 +151,7 @@ def wraps_tito(arg):
 ```
 
 From this code, Pysa can infer a model documenting that `wraps_tito`'s `arg`
-will also end up (indirectly) propagated to the return value of the fucntion:
+will also end up (indirectly) propagated to the return value of the function:
 
 ```python
 def wraps_tito(arg: TaintInTaintOut): ...


### PR DESCRIPTION
Scope of changes is restricted to docs only.
Corrections made in agreement with Standard American English.