### PR TITLE
Remove redundant pip install and add install for sapp

### DIFF
--- a/documentation/pysa_tutorial/Dockerfile
+++ b/documentation/pysa_tutorial/Dockerfile
@@ -14,5 +14,4 @@ WORKDIR /pyre-check
 COPY . .
 
 RUN pip3 install psutil
-RUN pip3 install pyre-check
-RUN pip3 install click click-log ipython==7.6.1 munch pygments SQLAlchemy ujson~=1.35 xxhash~=1.3.0 prompt-toolkit~=2.0.9 flask flask_cors flask_graphql graphene_sqlalchemy
+RUN pip3 install pyre-check fb-sapp

--- a/documentation/pysa_tutorial/README.md
+++ b/documentation/pysa_tutorial/README.md
@@ -38,8 +38,7 @@ project.
 
       python3 -m venv tutorial
       source tutorial/bin/activate
-      pip3 install pyre-check
-      pip3 install click click-log ipython==7.6.1 munch pygments SQLAlchemy ujson~=1.35 xxhash~=1.3.0 prompt-toolkit~=2.0.9 flask flask_cors flask_graphql graphene graphene_sqlalchemy
+      pip3 install pyre-check fb-sapp
       ```
 
       *Others* -


### PR DESCRIPTION
Issue #444 pointed out that SAPP is missing from the venv when doing the tutorial. This is because we removed `pyre-check`s dependency on `fb-sapp`, so that users of Pyre wouldn't have to bring in a whole web server when all they wanted was a type checker. This change updates our `Dockerfile` and `README.md` to now explicitly install `fb-sapp`.

Additionally, we've fixed the dependencies on the `fb-sapp` package, and we no longer need to explicitly install dependencies like `flask` or `click`. For that reason, I've also removed the now redundant extra `pip install` lines.

Test Plan:
Removed my old venv:
```
rm -rf tutorial/
```
Set up a new one with just `pyre-check` and `fb-sapp`:
```
pip3 install pyre-check fb-sapp
```
Ran exercise 4, which requires both:
```
pyre analyze --no-verify --save-results-to .
sapp analyze taint-output.json
sapp explore
```
Was able to interactively explore models in SAPP