### PR TITLE
Mirror internal linter behaviour in open source

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,6 @@ exclude =
   _ig_fbcode_wheel/*,
   buck-out/*,
   third-party-buck/*,
-  third-party2/*
+  third-party2/*,
+  source/interprocedural_analyses/taint/test/integration/*,
+  source/command/test/integration/fake_repository/*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,13 +14,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
 
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install black==20.8b1
+      - name: Install black
+        run: pip install black==21.4b2
 
-      - name: Run Black
-        run: |
-          black --check --diff .
+      - name: Run black
+        run: black --check --diff .
+
+  usort:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install usort
+        run: pip install usort==0.6.4
+
+      - name: Run usort
+        run: usort diff . && usort check .
+
+  flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        run: flake8

--- a/api/connection.py
+++ b/api/connection.py
@@ -10,7 +10,7 @@ import logging
 import subprocess
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from typing_extensions import TypedDict
 

--- a/api/query.py
+++ b/api/query.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import re
 from dataclasses import dataclass
 from functools import lru_cache
 from itertools import islice

--- a/client/commands/v2/persistent.py
+++ b/client/commands/v2/persistent.py
@@ -449,7 +449,7 @@ async def _start_pyre_server(
             )
 
         return StartSuccess()
-    except Exception as error:
+    except Exception:
         detail = traceback.format_exc()
         LOG.error(f"Exception occured during server start. {detail}")
         return StartFailure(detail)

--- a/client/commands/v2/restart.py
+++ b/client/commands/v2/restart.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from pathlib import Path
 
 from ... import command_arguments, commands, configuration as configuration_module
 from . import incremental, stop, remote_logging

--- a/client/filesystem.py
+++ b/client/filesystem.py
@@ -5,7 +5,6 @@
 
 import errno
 import fcntl
-import functools
 import logging
 import os
 import shutil

--- a/client/log/log.py
+++ b/client/log/log.py
@@ -9,7 +9,6 @@ import copy
 import io
 import logging
 import logging.handlers
-import os
 import re
 import subprocess
 import sys

--- a/client/tests/configuration_monitor_test.py
+++ b/client/tests/configuration_monitor_test.py
@@ -7,7 +7,7 @@ import unittest
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, Optional
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from .. import configuration_monitor, watchman, configuration as configuration_module
 from ..analysis_directory import AnalysisDirectory

--- a/client/tests/filesystem_test.py
+++ b/client/tests/filesystem_test.py
@@ -38,7 +38,6 @@ from ..filesystem import (
     find_python_paths,
     remove_if_exists,
 )
-from ..find_directories import FoundRoot
 
 
 class FilesystemTest(unittest.TestCase):

--- a/documentation/examples/pytorch/sources/_torch/__init__.py
+++ b/documentation/examples/pytorch/sources/_torch/__init__.py
@@ -10,7 +10,6 @@ from typing import TypeVar
 
 import torch
 from pyre_extensions import Generic, ListVariadic
-from pyre_extensions.type_variable_operators import Concatenate
 from torch import cat, mm, randn, unsqueeze  # noqa
 
 from .nn import Linear  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.usort]
+first_party_detection = false

--- a/pyre_extensions/tests/simple_tests.py
+++ b/pyre_extensions/tests/simple_tests.py
@@ -69,8 +69,7 @@ class BasicTestCase(unittest.TestCase):
 
     def test_generic(self) -> None:
         try:
-            from typing import TypeVar
-
+            from typing import TypeVar  # usort: skip wants trailing whitespace
             from .. import Generic, ListVariadic
             from ..type_variable_operators import Concatenate
 

--- a/tools/generate_taint_models/__init__.py
+++ b/tools/generate_taint_models/__init__.py
@@ -12,7 +12,7 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set, Type
+from typing import Dict, List, Optional, Set
 
 from typing_extensions import Final
 

--- a/tools/generate_taint_models/get_globals.py
+++ b/tools/generate_taint_models/get_globals.py
@@ -38,7 +38,8 @@ class GlobalModelGenerator(ModelGenerator[Model]):
             blacklisted_global_directories or set()
         )
 
-    def _globals(self, root: str, path: str) -> Iterable[Model]:
+    # flake8 suggests to reduce the complexity of the function, hence the noqa line
+    def _globals(self, root: str, path: str) -> Iterable[Model]:  # noqa: C901
         globals = set()
         # The parent of the property needs to be stored as well, as we only store the
         # module qualifier.

--- a/tools/generate_taint_models/tests/get_annotated_free_functions_with_decorator_test.py
+++ b/tools/generate_taint_models/tests/get_annotated_free_functions_with_decorator_test.py
@@ -11,7 +11,6 @@ from typing import List, Set
 from unittest.mock import MagicMock, mock_open, patch
 
 from .. import annotated_function_generator
-from .. import get_annotated_free_functions_with_decorator
 from ..generator_specifications import (
     AllParametersAnnotation,
     AnnotationSpecification,

--- a/tools/generate_taint_models/tests/module_loader_test.py
+++ b/tools/generate_taint_models/tests/module_loader_test.py
@@ -10,7 +10,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
-from typing import IO, Any
+from typing import IO
 from unittest.mock import MagicMock, mock_open, patch
 
 from .. import module_loader

--- a/tools/incremental_test/main.py
+++ b/tools/incremental_test/main.py
@@ -102,7 +102,7 @@ def main(arguments: argparse.Namespace) -> int:
         LOG.exception(f"Cannot parse JSON at {specification_path}")
         return ExitCode.FAILURE
     except InvalidSpecificationException:
-        LOG.exception(f"Invalid specification JSON")
+        LOG.exception("Invalid specification JSON")
         return ExitCode.FAILURE
     except Exception:
         LOG.exception("Exception occurs in the check")

--- a/tools/incremental_test/runner.py
+++ b/tools/incremental_test/runner.py
@@ -258,7 +258,7 @@ def compare_server_to_full(
 
         LOG.info("Running pyre incremental check...")
         incremental_check_output = pyre_runner.run_incremental()
-        LOG.debug(f"Stopping pyre server...")
+        LOG.debug("Stopping pyre server...")
         pyre_runner.run_stop()
         LOG.info(
             f"Pyre incremental check successfully finished (with {len(incremental_check_output)} errors)."  # noqa: line too long
@@ -291,7 +291,7 @@ def benchmark_server(
 
         LOG.info("Running pyre incremental check...")
         incremental_check_output = pyre_runner.run_incremental()
-        LOG.debug(f"Stopping pyre server...")
+        LOG.debug("Stopping pyre server...")
         pyre_runner.run_stop()
         LOG.info(
             f"Pyre incremental check successfully finished (with {len(incremental_check_output)} errors)."  # noqa: line too long

--- a/tools/incremental_test/specification.py
+++ b/tools/incremental_test/specification.py
@@ -59,7 +59,7 @@ class RepositoryState(ABC):
                 )
             else:
                 raise InvalidSpecificationException(
-                    f"Cannot create RepositoryState due to unrecognized kind"
+                    "Cannot create RepositoryState due to unrecognized kind"
                 )
         except KeyError as key:
             raise InvalidSpecificationException(
@@ -118,7 +118,7 @@ class RepositoryUpdate(ABC):
                 return BatchRepositoryUpdate(parsed_updates)
             else:
                 raise InvalidSpecificationException(
-                    f"Cannot create RepositoryUpdate due to unrecognized kind"
+                    "Cannot create RepositoryUpdate due to unrecognized kind"
                 )
         except KeyError as key:
             raise InvalidSpecificationException(
@@ -154,7 +154,7 @@ class HgRepositoryState(RepositoryState):
     def _do_prepare(self, environment: Environment) -> Iterator[Path]:
         # Save the original commit hash.
         hg_output = environment.checked_run(
-            working_directory=self.repository, command=f"hg whereami"
+            working_directory=self.repository, command="hg whereami"
         ).stdout.strip()
         original_commit_hash = hg_output if len(hg_output) > 0 else None
         LOG.debug(f"Original hg commit = {original_commit_hash}")

--- a/tools/sandbox/application.py
+++ b/tools/sandbox/application.py
@@ -51,7 +51,7 @@ class Pyre:
 
         LOG.debug(f"Starting server in `{self._directory}`...")
         pyre_configuration = textwrap.dedent(
-            f"""
+            """
                 {{
                     "source_directories": ["."]
                 }}
@@ -61,14 +61,14 @@ class Pyre:
         pyre_configuration_path = self._directory / ".pyre_configuration"
         pyre_configuration_path.write_text(pyre_configuration)
 
-        LOG.debug(f"Writing watchman configuration")
+        LOG.debug("Writing watchman configuration")
         watchman_configuration_path = self._directory / ".watchmanconfig"
         watchman_configuration_path.write_text("{}\n")
 
-        LOG.debug(f"Starting watchman")
+        LOG.debug("Starting watchman")
         subprocess.check_call(["watchman", "watch", str(self._directory)])
 
-        LOG.debug(f"Priming the server")
+        LOG.debug("Priming the server")
         # TODO(T82114844): incremental is borked on Ubuntu 20.04.
         subprocess.check_call(
             ["pyre", "--noninteractive", "check"], cwd=self._directory


### PR DESCRIPTION
Mirror the Facebook internally used linter/formatter behaviour in the
open source repository.

Pins to black and usort versions used in the internal linter and runs
black, flake8, and usort in seperate runner instances.

Adds pyproject.toml with identical usort configuration as used
internally.

Modifies flake8 configuration to match the one used internally.

Fix errors reported by flake8, black, and usort.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/24