### PR TITLE
Add DSL model generator for tornado RequestHandler

### DIFF
--- a/stubs/third_party_taint/tornado_sources_sinks.pysa
+++ b/stubs/third_party_taint/tornado_sources_sinks.pysa
@@ -45,3 +45,22 @@ tornado.httputil.HTTPServerRequest.body: TaintSource[UserControlled, UserControl
 tornado.httputil.HTTPServerRequest.arguments: TaintSource[UserControlled, UserControlled_Payload]
 tornado.httputil.HTTPServerRequest.query_arguments: TaintSource[UserControlled, UserControlled_Payload]
 tornado.httputil.HTTPServerRequest.body_arguments: TaintSource[UserControlled, UserControlled_Payload]
+
+ModelQuery(
+  find = "methods",
+  where = [
+    parent.extends("tornado.web.RequestHandler", is_transitive=True),
+    AnyOf(
+      name.matches("\.get$"),
+      name.matches("\.post$"),
+      name.matches("\.head$"),
+      name.matches("\.delete$"),
+      name.matches("\.patch$"),
+      name.matches("\.put$"),
+      name.matches("\.options$"),
+    )
+  ],
+  model = [
+    AllParameters(TaintSource[UserControlled, UserControlled_Parameter], exclude="self")
+  ]
+)


### PR DESCRIPTION
A way to define HTTPRequest handler with tornado is to subclass
tornad.web.RequestHandler and implement methods. Reviewed the API and
implements a DSL model generattor to automatically create UserControlled
models.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes https://github.com/MLH-Fellowship/pyre-check/issues/29