### PR TITLE
Adds taint sources for wtforms and flaskwtf

### DIFF
--- a/stubs/third_party_taint/wtforms_sources.pysa
+++ b/stubs/third_party_taint/wtforms_sources.pysa
@@ -1,0 +1,14 @@
+ModelQuery(
+  find = "attributes",
+  where = [
+    AnyOf(
+      parent.extends("wtforms.form.Form", is_transitive=True),
+      parent.extends("flaskwtf.form.FlaskForm", is_transitive=True),
+    ),
+  ],
+  model = [
+    AttributeModel(
+      TaintSource[UserControlled, UserControlled_Parameter],
+    )
+  ]
+)


### PR DESCRIPTION
Adds taint sources for wtforms and flaskwtf. The way either of the two
libraries are used is by inheriting the Form class by a user defined
class. Since, pyre can't find the data attribute of the Form or the
Field (they are created dynamically), tainting all attributes of classes
inheriting from Form class of flaskwtf and wtforms.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes https://github.com/MLH-Fellowship/pyre-check/issues/36 and https://github.com/MLH-Fellowship/pyre-check/issues/37