### PR TITLE
Updated tests scripts to run tests from one directory higher

### DIFF
--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -40,7 +40,7 @@ jobs:
           unzip -qq ./stubs/typeshed/typeshed.zip -d ./typeshed/
           ./scripts/setup.sh --local --no-tests
           make -C source
-          echo "PYTHONPATH=$GITHUB_WORKSPACE:$PYTHONPATH" >> $GITHUB_ENV
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/..:$PYTHONPATH" >> $GITHUB_ENV
           echo "pythonLocation=$GITHUB_WORKSPACE:$pythonLocation" >> $GITHUB_ENV
           echo "PYRE_BINARY=$GITHUB_WORKSPACE/source/_build/default/main.exe" >> $GITHUB_ENV
           echo "PYRE_TYPESHED=$GITHUB_WORKSPACE/typeshed/typeshed-master/" >> $GITHUB_ENV

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -7,10 +7,10 @@
 set -e
 
 SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "${SCRIPTS_DIRECTORY}/.."
+cd "${SCRIPTS_DIRECTORY}/../.."
 
 echo '  Enumerating test files:'
-files=$(find client -name '*_test.py' ! -name 'watchman_test.py')
+files=$(find 'pyre-check/client' -name '*_test.py' ! -name 'watchman_test.py')
 echo "${files}"
 if [[ -z "${files}" ]]; then
   echo 'No test files found, exiting.'

--- a/tools/pysa_integration_tests/utils.py
+++ b/tools/pysa_integration_tests/utils.py
@@ -155,7 +155,7 @@ def run_pysa_integration_test(
     if run_from_source:
         command = [
             "python",
-            "-m" "client.pyre",
+            "-m" "pyre-check.client.pyre",
             "--noninteractive",
             "analyze",
         ]


### PR DESCRIPTION
Related to discussion on this with @gbleaney. 

PR #433's use of relative imports causes `Import beyond top-level package` errors. Internally, relative imports are required to pass the tests whereas on GitHub, this causes issues. This PR fixes that issue by running tests from one directory higher, unblocking #433.
