### PR TITLE
Lint: Fix failing flake8 tests

### DIFF
--- a/scripts/download_typeshed.py
+++ b/scripts/download_typeshed.py
@@ -15,7 +15,7 @@ import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 LOG: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The flake8 test was failing due to an unused import in
./scripts/download_typeshed.py. Removed the ununsed import.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>