### PR TITLE
Pin a node package version exactly

### DIFF
--- a/client/statistics_logger.py
+++ b/client/statistics_logger.py
@@ -9,7 +9,6 @@ import os
 import platform
 import subprocess
 import time
-import traceback
 from enum import Enum
 from typing import Dict, Optional
 

--- a/documentation/website/package.json
+++ b/documentation/website/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.61",
     "classnames": "^2.2.6",
     "codemirror": "^5.59.0",
-    "docusaurus-plugin-internaldocs-fb": "^0.9.2",
+    "docusaurus-plugin-internaldocs-fb": "0.9.2",
     "internaldocs-fb-helpers": "^1.2.0",
     "react": "^16.10.2",
     "react-codemirror2": "^7.2.1",

--- a/documentation/website/yarn.lock
+++ b/documentation/website/yarn.lock
@@ -3414,12 +3414,14 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-docusaurus-plugin-internaldocs-fb@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/docusaurus-plugin-internaldocs-fb/-/docusaurus-plugin-internaldocs-fb-0.8.5.tgz#8f9d88fd4bce4f3d0601b2ec1369bcba305f53b7"
-  integrity sha512-cfxfmMB0yb/5b/g0NmjJc8p3WdHx9wI5cqFl5R9uJsg5HF4RR0isHwxAh3/KRCd2MKClILL/relShsnim4oQ9Q==
+docusaurus-plugin-internaldocs-fb@0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-internaldocs-fb/-/docusaurus-plugin-internaldocs-fb-0.9.2.tgz#a26d0729d38f803297b2f589b8b1fd635def01be"
+  integrity sha512-bYxW73C0dQlij8QhTaC2FMcHwVq1ggZTKP5tgd3gK+hZlrS24VcEXGVTsJ6n+nTn6ETzhL9aeb/N9g5jFdFYkA==
   dependencies:
-    internaldocs-fb-helpers "^1.6.4"
+    clsx "^1.1.1"
+    fs-extra "^10.0.0"
+    internaldocs-fb-helpers "^1.7.0"
     remark-code-snippets "^1.0.1"
     remark-mdx-filter-imports "^0.1.2"
 
@@ -4073,6 +4075,15 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -4738,10 +4749,15 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
-internaldocs-fb-helpers@^1.2.0, internaldocs-fb-helpers@^1.6.4:
+internaldocs-fb-helpers@^1.2.0:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/internaldocs-fb-helpers/-/internaldocs-fb-helpers-1.6.4.tgz#b67cbf83a83cbd720067847af21c499715b9e32a"
   integrity sha512-eoMHtKcd7zVp0LNVdCPpP8NJQ9zDyCqQCr/yXL0z4rJdOaZCbsbAbW/We2IBxDKKCg6ItheFAVrAv1PF4v7+Sg==
+
+internaldocs-fb-helpers@^1.7.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/internaldocs-fb-helpers/-/internaldocs-fb-helpers-1.7.1.tgz#ab337a74fc2701927305e402e423000e93fa9f66"
+  integrity sha512-QKxEzY2lz/uATPBjCNTsP38jtC2q0IIxPWzFWhPL+lsitn8d5a5PGwKCwVYAK4ddkvLmFvYyehCNT7h/jXvwuA==
 
 interpret@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
Summary:
It looks to me like there was an incorrect version
bump in one of the docusaurus modules - the latest
version of
`docusaurus-plugin-internaldocs-fb` marked as
compatible with 0.9.2 is in fact depending on breaking
changes in `docusaurus` core, which is breaking both
pyre's github CI jobs and local development after a fresh
`yarn install`.

The specific problem is that the floating version of
`internaldocs` is making use of
'docusaurus/useIsBrowser', which does not exist
in the docusaurus version range we are using. But the details
aren't very interesting, it's just a version mismatch problem.

As a quick fix, I'm pinning to 0.9.2 exactly. I'm also filing
a ticket to upgrade to the latest everything, which may take
some time; in my first attempt I ran into validation errors.

Differential Revision: D30711366

