### PR TITLE
Hook github actions up to tox

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,6 +16,7 @@ max-complexity = 50
 exclude =
   .git,
   .hg,
+  .tox,
   __pycache__,
   _bin/*,
   _build/*,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,18 +9,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
+  test:
+
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run Tests
-        run: |
-          ./scripts/run-python-tests.sh
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run tox on python version from matrix
+        run: tox -e py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ first_party_detection = false
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, lint
 skipsdist = True
 
 [testenv]
@@ -17,4 +17,14 @@ allowlist_externals =
     bash
 commands =
     bash scripts/run-python-tests.sh
+
+[testenv:lint]
+deps =
+    black
+    usort
+    flake8
+commands =
+    black --check --diff client scripts tools
+    usort check client scripts tools
+    flake8 client scripts tools
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,20 @@
 [tool.usort]
 first_party_detection = false
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+envlist = py36, py37, py38, py39
+skipsdist = True
+
+[testenv]
+passenv =
+    http_proxy
+    https_proxy
+deps =
+    -rrequirements.txt
+allowlist_externals =
+    bash
+commands =
+    bash scripts/run-python-tests.sh
+"""


### PR DESCRIPTION
Summary:
In a previous commit, we added a `[tool.tox]` section to
pyproject.toml so that we can run tests and lints on local
code in a tox-controlled way.

This commit uses that same setup to power the github tests,
following the pattern described in github actions docs at
https://docs.github.com/en/actions/guides/building-and-testing-python#running-tests-with-tox
to convert from the github python matrix to tox.

Differential Revision: D30788133

