### PR TITLE
Modify pyre sandbox to add support for Pysa

### DIFF
--- a/tools/sandbox/application.py
+++ b/tools/sandbox/application.py
@@ -2,13 +2,15 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
 
 import argparse
 import json
 import logging
+import os
 import subprocess
 import tempfile
-import textwrap
 import threading
 from pathlib import Path
 from typing import IO, List
@@ -23,6 +25,11 @@ logging.basicConfig(
 )
 
 LOG: logging.Logger = logging.getLogger(__name__)
+
+CUSTOM_PYSA_MODEL_FILE: str = "custom.py"
+WATCHMAN_CONFIG_FILE: str = ".watchmanconfig"
+PYRE_CONFIG_FILE: str = ".pyre_configuration"
+INPUT_FILE: str = "input.py"
 
 
 def _consume(stream: IO[str]) -> str:
@@ -50,19 +57,17 @@ class Pyre:
         self._directory: Path = Path(tempfile.mkdtemp())
 
         LOG.debug(f"Starting server in `{self._directory}`...")
-        pyre_configuration = textwrap.dedent(
-            """
-                {{
-                    "source_directories": ["."]
-                }}
-            """
+        pyre_configuration = json.dumps(
+            {
+                "source_directories": ["."],
+            }
         )
         LOG.debug(f"Writing configuration:\n{pyre_configuration}")
-        pyre_configuration_path = self._directory / ".pyre_configuration"
+        pyre_configuration_path = self._directory / PYRE_CONFIG_FILE
         pyre_configuration_path.write_text(pyre_configuration)
 
         LOG.debug("Writing watchman configuration")
-        watchman_configuration_path = self._directory / ".watchmanconfig"
+        watchman_configuration_path = self._directory / WATCHMAN_CONFIG_FILE
         watchman_configuration_path.write_text("{}\n")
 
         LOG.debug("Starting watchman")
@@ -75,8 +80,8 @@ class Pyre:
         )
 
     def check(self, input: str) -> str:
-        LOG.debug(f"Writing code:\n{input}")
-        code_path = self._directory / "input.py"
+        LOG.debug("Running pyre check")
+        code_path = self._directory / INPUT_FILE
         code_path.write_text(input)
 
         # TODO(T82114844): incremental is borked on Ubuntu 20.04.
@@ -105,7 +110,67 @@ class Pyre:
             return result
 
 
-pyre = Pyre()
+class Pysa:
+    def __init__(
+        self, model: str = "", use_builtin_pysa_models: bool = False
+    ) -> None:
+        self._directory: Path = Path(tempfile.mkdtemp())
+        self._stubs: Path = Path(tempfile.mkdtemp())
+
+        LOG.debug(f"Intializing Pysa in `{self._directory}`...")
+        pyre_configuration = json.dumps(
+            {
+                "source_directories": ["."],
+                "taint_models_path": [
+                    str(self._stubs),
+                    os.environ["PYSA_PLAYGROUND_STUBS"],
+                ]
+                if use_builtin_pysa_models
+                else str(self._stubs),
+                "search_path": [str(self._stubs)],
+            }
+        )
+        LOG.debug(f"Writing configuration:\n{pyre_configuration}")
+        pyre_configuration_path = self._directory / PYRE_CONFIG_FILE
+        pyre_configuration_path.write_text(pyre_configuration)
+        if model:
+            LOG.debug("Writing custom model to pysa file")
+            model_path = self._stubs / CUSTOM_PYSA_MODEL_FILE
+            model_path.write_text(model)
+
+    def analyze(self, input: str) -> str:
+        LOG.debug(f"Writing code:\n{input}")
+        code_path = self._directory / INPUT_FILE
+        code_path.write_text(input)
+
+        LOG.debug("Running pysa")
+        with subprocess.Popen(
+            ["pyre", "-n", "analyze"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            cwd=self._directory,
+            text=True,
+        ) as process:
+            process_stderr = process.stderr
+            stderr = ""
+            if process_stderr is not None:
+                stderr = _consume(process_stderr)
+            process_stdout = process.stdout
+            stdout = ""
+            if process_stdout is not None:
+                stdout = _consume(process_stdout)
+            return_code = process.wait()
+
+            if return_code != 0:
+                LOG.error(f"Returning error: {stderr}")
+                result = jsonify(errors=[stderr])
+            else:
+                errors = json.loads(stdout)
+                result = jsonify(data={"errors": errors, "stderr": stderr})
+
+            return result
+
+
 application = Flask(__name__)
 CORS(application)
 
@@ -121,7 +186,32 @@ def check() -> str:
         return jsonify(errors=["Input not provided"])
 
     LOG.info(f"Checking `{input}`...")
+    pyre = Pyre()
     return pyre.check(input)
+
+
+@application.route("/analyze", methods=["POST"])
+def analyze() -> str:
+    input = (
+        request.args.get("input")
+        or request.form.get("input")
+        or request.json.get("input")
+    )
+    use_builtin_pysa_models = bool(
+        request.args.get("use_builtin_pysa_models")
+        or request.form.get("use_builtin_pysa_models")
+        or request.json.get("use_builtin_pysa_models")
+    )
+    model = (
+        request.args.get("model")
+        or request.form.get("model")
+        or request.json.get("model")
+    )
+    if input is None:
+        return jsonify(errors=["Input not provided"])
+    pysa = Pysa(model, use_builtin_pysa_models)
+    LOG.info(f"Checking `{input}`...")
+    return pysa.analyze(input)
 
 
 @application.route("/")


### PR DESCRIPTION
Modifies pyre sandbox and adds in support for running pysa. This is done
by modifying how the Pyre object is created and by adding an additional
analyze endpoint to the flask app. Adds support for adding user-defined
as well as the open source models for pysa.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

Test Plan
- Pull in #509 and then build the frontend with
```shell
cd documentation/website
yarn install
yarn start
```
- Build and run the backend in a virtual environment:
```shell
python3 -m venv ~/venvs/sandbox
source ~/venvs/sandbox/bin/activate
cd tools/sandbox
export PYSA_PLAYGROUND_STUBS=<path-to-your-pyre-check-repo>/stubs
pip3 install -r requirements.txt
python3 application.py --debug
```
- Goto `http://localhost:3000/pysa-playground` and play around in the playground

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes https://github.com/MLH-Fellowship/pyre-check/issues/79