### PR TITLE
Adds a pysa quick start command: init-pya

### DIFF
--- a/client/commands/v2/__init__.py
+++ b/client/commands/v2/__init__.py
@@ -10,6 +10,7 @@ from . import coverage  # noqa F401
 from . import incremental  # noqa F401
 from . import infer  # noqa F401
 from . import initialize  # noqa F401
+from . import initialize_pysa  # noqa F401
 from . import kill  # noqa F401
 from . import persistent  # noqa F401
 from . import profile  # noqa F401

--- a/client/commands/v2/initialize_pysa.py
+++ b/client/commands/v2/initialize_pysa.py
@@ -1,0 +1,83 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from ... import log, commands
+from ...find_directories import find_taint_models_directory
+
+LOG: logging.Logger = logging.getLogger(__name__)
+
+
+class PysaInitializationError(Exception):
+    pass
+
+
+def run() -> int:
+    try:
+        working_directory = Path(os.getcwd()).resolve()
+        # Check if venv is in working_directory
+        venv_path = (
+            # pyre-fixme[6]: Incompatible parameter type for `Path`, expected `str`
+            Path(os.environ.get("VIRTUAL_ENV")).resolve()
+            if os.environ.get("VIRTUAL_ENV", False)
+            else None
+        )
+        if venv_path is not None and str(working_directory) in str(
+            venv_path.parent.absolute()
+        ):
+            raise PysaInitializationError(
+                "Can't use a virtual environment in the project directory."
+                " Please use one outside the project directory."
+            )
+
+        # Install dependencies
+        install_dependencies = log.get_yes_no_input(
+            "Would you like to install the project dependencies now?"
+        )
+        if install_dependencies:
+            requirements_file = "requirements.txt"
+            if not os.path.isfile(working_directory / requirements_file):
+                requirements_file = Path(
+                    log.get_input(
+                        f"requirements.txt file not found in `{working_directory}`"
+                        " Please enter its location (eg: ./requirements-dev.txt): "
+                    )
+                )
+                requirements_file = working_directory / requirements_file
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "-r", requirements_file],
+                check=True,
+            )
+        else:
+            LOG.warning(
+                "You have chosen not to install dependencies."
+                " Please install dependencies before running Pysa to get best results."
+            )
+        run_infer = log.get_yes_no_input("Would you like to generate type annotations?")
+        if run_infer:
+            subprocess.run(["pyre", "infer", "-i"], check=True)
+        pyre_check_path = find_taint_models_directory()
+        if pyre_check_path and os.path.isdir(pyre_check_path / "pyre_check"):
+            pyre_check_path = pyre_check_path / "pyre_check"
+            LOG.info("Importing filters to sapp")
+            subprocess.run(["sapp", "filter", "import", pyre_check_path], check=True)
+        else:
+            LOG.warning(
+                "Couldn't infer filter directory, skipping filter import to sapp."
+            )
+        LOG.log(
+            log.SUCCESS,
+            "Successfully initialized an environemnt to run Pysa!\n"
+            + "  You can now run Pysa with `pyre analyze`.",
+        )
+        return commands.ExitCode.SUCCESS
+    except Exception as error:
+        LOG.error(f"Couldn't complete Pysa initialization:\n{error}")
+        return commands.ExitCode.FAILURE

--- a/client/pyre.py
+++ b/client/pyre.py
@@ -915,6 +915,19 @@ def init(context: click.Context, local: bool) -> int:
 
 
 @pyre.command()
+@click.pass_context
+def init_pysa(context: click.Context) -> int:
+    """
+    Creates a suitable environment for running pyre analyze.
+    """
+    create_configuration_return_code: int = v2.initialize.run()
+    if create_configuration_return_code == ExitCode.SUCCESS:
+        return v2.initialize_pysa.run()
+    else:
+        return create_configuration_return_code
+
+
+@pyre.command()
 @click.option(
     "--with-fire", is_flag=True, default=False, help="A no-op flag that adds emphasis."
 )


### PR DESCRIPTION
Adds a pysa quick command: init-pysa, that helps users setup a suitable
environment to run pysa. It handles commonly found issues in pysa and
creates the best possible environment while handling some of the edge
cases.

Test Plan
- create (or enter into the directory of) a python project you'd like to run pysa on
- install pyre from source (see installation docs) (suitably create an alias for the client)
- run `pyre init-pysa`

Preview:
<img width="1440" alt="Preview" src="https://user-images.githubusercontent.com/8947010/138034978-cfca26f0-d857-45a6-b5ab-0d315b0e3c49.png">

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/80
