### PR TITLE
Trigger website build on open source PRs

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -3,7 +3,8 @@ name: publish website
 on:
   push:
     branches: [ main ]
-
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -24,6 +25,7 @@ jobs:
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy
+      if: ${{ github.event_name == 'push' }}
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Pre-submission checklist**
- [ N/A ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
    - [ N/A ] `pre-commit run`

## Summary

Publishing of the Pysa website has been [broken for a few weeks](https://github.com/facebook/pyre-check/actions/workflows/publish_website.yml). #514 contains the version upgrade needed to fix this, but currently the website build is only triggering when the `main` branch is updated, rather than on PRs. This PR updates the `publish_website` workflow to also run on PRs, but in a dry run mode that skips the final publish step.

## Test Plan

Action ran on this PR, but didn't trigger deployment (as intended):
https://github.com/facebook/pyre-check/runs/3978033955?check_suite_focus=true