### PR TITLE
Add open-source python files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ website/i18n/*
 hack_parallel/hack_parallel/utils/get_build_id.c
 /.buckd
 /buck-out
+*.egg-info
+.python-version
 
 node_modules/
 tools/ide_plugins/pysa-vscode/out


### PR DESCRIPTION

## Summary

It's standard to pip install packages locally, which produces
a `*.egg-info` file, and it's also usually a good idea to use
pyenv which means setting a .python-version file.


## Test Plan

`git status` doesn't show my `*.egg-info` or `.python-version` files, so `git commit -a` won't pick them up
