### PR TITLE
Fix unit tests that are broken on OSX due to links

### DIFF
--- a/client/commands/v2/tests/statistics_test.py
+++ b/client/commands/v2/tests/statistics_test.py
@@ -38,7 +38,7 @@ class StatisticsTest(testslide.TestCase):
 
     def test_find_roots__filter_path_expand(self) -> None:
         with tempfile.TemporaryDirectory() as root:
-            root_path = Path(root)
+            root_path = Path(root).resolve()  # resolve is necessary on OSX 11.6
             with setup.switch_working_directory(root_path):
                 self.assertCountEqual(
                     find_roots(
@@ -67,7 +67,7 @@ class StatisticsTest(testslide.TestCase):
 
     def test_find_roots__current_working_directory(self) -> None:
         with tempfile.TemporaryDirectory() as root:
-            root_path = Path(root)
+            root_path = Path(root).resolve()  # resolve is necessary on OSX 11.6
             with setup.switch_working_directory(root_path):
                 self.assertCountEqual(
                     find_roots(


### PR DESCRIPTION
In OSX 11.6, it looks like the output of `tempfile.TemporaryDirectory()`
is not necessarily a true, fully-resolved path but the output of
`Path.cwd()` is. As a result, it's necessary for us to fully-resolve
the temporary directory in a couple of the unit tests to avoid
mismatched paths.


# Test Plan

```
./scripts/run-python-tests.sh
```
which reported two failures prior to this change, none after.
