### PR TITLE
Clean up unclassified errors in the model parser

### DIFF
--- a/source/interprocedural_analyses/taint/modelVerificationError.mli
+++ b/source/interprocedural_analyses/taint/modelVerificationError.mli
@@ -80,9 +80,24 @@ module T : sig
     | InvalidIdentifier of Expression.t
     | ClassBodyNotEllipsis of string
     | DefineBodyNotEllipsis of string
-    | UnclassifiedError of {
+    | UnsupportedCallee of Expression.t
+    | UnexpectedTaintAnnotation of string
+    | UnexpectedModelExpression of Expression.t
+    | UnsupportedFindClause of string
+    | InvalidFindClauseType of Expression.t
+    | InvalidReturnAnnotation of {
         model_name: string;
-        message: string;
+        annotation: string;
+      }
+    | UnsupportedConstraint of Expression.t
+    | InvalidModelForTaint of {
+        model_name: string;
+        error: string;
+      }
+    | NoCorrespondingCallable of string
+    | InvalidAnnotationForAttributeModel of {
+        name: Reference.t;
+        annotation: string;
       }
   [@@deriving sexp, compare, eq]
 

--- a/source/interprocedural_analyses/taint/test/modelTest.ml
+++ b/source/interprocedural_analyses/taint/test/modelTest.ml
@@ -1917,7 +1917,7 @@ let test_invalid_models context =
     ();
   assert_invalid_model
     ~model_source:"def test.source() -> TaintInTaintOut: ..."
-    ~expect:"Invalid model for `test.source`: Invalid return annotation: TaintInTaintOut"
+    ~expect:"Invalid model for `test.source`: Invalid return annotation `TaintInTaintOut`."
     ();
   assert_invalid_model
     ~model_source:"def test.sink(parameter: TaintInTaintOut[Test]): ..."


### PR DESCRIPTION
Clean up unclassified errors by mitigating each errors to corresponding
error types instead of a single unclassified error type.

Changes are done in such a way that the messages are made identical to
previous ones as much as possible. Thus, this is just a implementation
change which should have no effect on the output.

Updates a test in modelTest to contain to new test results given the
previous commit.

Test Plan
- Recompile the ocaml files from scratch:
```
cd scripts && ./setup.sh --local
cd source
make
```
- Run tests: `make tests` see all of them pass.
- Run pyre (with updated `PYRE_BINARY` pointing towards the exe file we just built)
`python3 -m client.pyre analyze`

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/85