### PR TITLE
Migrate pysa playground backend to websockets

### DIFF
--- a/tools/sandbox/requirements.txt
+++ b/tools/sandbox/requirements.txt
@@ -10,6 +10,7 @@ fb-sapp==0.2.8
 Flask==1.1.2
 Flask-Cors==3.0.9
 Flask-GraphQL==2.0.1
+flask-socketio==5.1.1
 graphene==2.1.8
 graphene-sqlalchemy==2.3.0
 graphql-core==2.3.2


### PR DESCRIPTION
Migrate pysa playground flask endpoints to websocket connections instead
of http connection. This enables us to provide the user with live
information about a particular run.

Test Plan
- stack #533 on top of this PR
- run the backend: `cd tools/sandbox && python3 application.py`
- run the frontend: `cd documentation/website && yarn start`
- goto the playground: http://locahost:3000/pysa_playground
- play around :)

Screencast:

https://user-images.githubusercontent.com/8947010/141153869-f476ad0c-285d-4993-a62a-d12cdd2601d6.mov


Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

