### PR TITLE
Fix the setup.py script in github

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -152,11 +152,15 @@ class Setup(NamedTuple):
             ]
         )
         opam_environment_variables: Dict[str, str] = {}
+        # `opam env` produces lines of two forms:
+        # - comments like ": this comment, starts with a colon;"
+        # - lines defining and exporting env vars like "ENV_VAR=value; export ENV_VAR;"
         for line in opam_env_result.split("\n"):
-            environment_variable, quoted_value = line.split(";")[0].split("=")
-            value = quoted_value[1:-1]
-            LOG.info(f'{environment_variable}="{value}"')
-            opam_environment_variables[environment_variable] = value
+            if not line.startswith(":"):
+                environment_variable, quoted_value = line.split(";")[0].split("=")
+                value = quoted_value[1:-1]
+                LOG.info(f'{environment_variable}="{value}"')
+                opam_environment_variables[environment_variable] = value
         return opam_environment_variables
 
     def initialize_opam_switch(self) -> Mapping[str, str]:


### PR DESCRIPTION
It looks like `opam env` just started producing some comment lines
as well as the lines defining environment variables.

We need to handle those comment lines, otherwise our split on "="
crashes the setup.

See this CI run on a PR where I had added some debugging print statements:
https://github.com/facebook/pyre-check/runs/4217294779?check_suite_focus=true