### PR TITLE
Remove sqlalchemy_1_4 from typeshed stubs

### DIFF
--- a/source/analysis/attributeResolution.ml
+++ b/source/analysis/attributeResolution.ml
@@ -2431,14 +2431,6 @@ class base class_metadata_environment dependency =
         ~name:"__table__"
         ~annotation:(Type.Primitive "sqlalchemy.sql.schema.Table")
         table;
-      add_special_attribute
-        ~name:"metadata"
-        ~annotation:(Type.Primitive "sqlalchemy_1_4.sql.schema.MetaData")
-        table;
-      add_special_attribute
-        ~name:"__table__"
-        ~annotation:(Type.Primitive "sqlalchemy_1_4.sql.schema.Table")
-        table;
       table
 
     method typed_dictionary_special_methods_table
@@ -2691,13 +2683,10 @@ class base class_metadata_environment dependency =
       with
       | Some definition, Some { is_typed_dictionary; is_test = in_test; _ } ->
           let is_declarative_sqlalchemy_class () =
-            match self#metaclass ~assumptions class_name with
-            | Some
-                (Type.Primitive
-                  ( "sqlalchemy.ext.declarative.api.DeclarativeMeta"
-                  | "sqlalchemy_1_4.ext.declarative.api.DeclarativeMeta" )) ->
-                true
-            | _ -> false
+            Option.equal
+              Type.equal
+              (self#metaclass ~assumptions class_name)
+              (Some (Type.Primitive "sqlalchemy.ext.declarative.api.DeclarativeMeta"))
           in
           let table =
             if is_typed_dictionary then

--- a/source/analysis/preprocessing.ml
+++ b/source/analysis/preprocessing.ml
@@ -2879,8 +2879,6 @@ let expand_sqlalchemy_declarative_base ({ Source.statements; _ } as source) =
           with
           | Some "sqlalchemy.ext.declarative.declarative_base", Some class_name_reference ->
               declarative_base_class_declaration ~base_module:"sqlalchemy" class_name_reference
-          | Some "sqlalchemy_1_4.ext.declarative.declarative_base", Some class_name_reference ->
-              declarative_base_class_declaration ~base_module:"sqlalchemy_1_4" class_name_reference
           | _ -> value)
       | _ -> value
     in

--- a/source/analysis/test/integration/sqlAlchemyTest.ml
+++ b/source/analysis/test/integration/sqlAlchemyTest.ml
@@ -58,35 +58,4 @@ let test_declarative_base context =
   ()
 
 
-let test_sqlalchemy_1_4 context =
-  let assert_sql_alchemy_errors = assert_type_errors ~context in
-  assert_sql_alchemy_errors
-    {|
-      from sqlalchemy_1_4.ext.declarative import declarative_base
-      from sqlalchemy_1_4 import Column, Integer
-      from typing import Optional
-      Base = declarative_base()
-
-      class User(Base):
-        __tablename__ = 'users'
-        id: Column[int] = Column(Integer(), primary_key=True)
-        age: Column[Optional[int]] = Column(Integer(), primary_key=False)
-        income: Column[Optional[int]] = Column(Integer())
-
-      user1: User = User()
-      user2: User = User(id=1)
-      user3: User = User(age=2)
-
-      user4: User = User(1, 2, 3)
-    |}
-    [
-      "Too many arguments [19]: Call `User.__init__` expects 0 positional arguments, 3 were \
-       provided.";
-    ];
-  ()
-
-
-let () =
-  "sqlAlchemy"
-  >::: ["declarative_base" >:: test_declarative_base; "sqlalchemy_1_4" >:: test_sqlalchemy_1_4]
-  |> Test.run
+let () = "sqlAlchemy" >::: ["declarative_base" >:: test_declarative_base] |> Test.run

--- a/source/analysis/test/preprocessingTest.ml
+++ b/source/analysis/test/preprocessingTest.ml
@@ -3467,14 +3467,6 @@ let test_sqlalchemy_declarative_base _ =
       class Base(metaclass=sqlalchemy.ext.declarative.DeclarativeMeta):
         pass
     |};
-  assert_expand
-    {|
-      Base = sqlalchemy_1_4.ext.declarative.declarative_base()
-    |}
-    {|
-      class Base(metaclass=sqlalchemy_1_4.ext.declarative.DeclarativeMeta):
-        pass
-    |};
   ()
 
 

--- a/source/test/test.ml
+++ b/source/test/test.ml
@@ -932,33 +932,6 @@ let typeshed_stubs ?(include_helper_builtins = true) () =
         |} );
     ]
   in
-  let sqlalchemy_1_4_stubs =
-    [
-      "sqlalchemy_1_4/__init__.pyi", {|
-      from ..sqlalchemy import *
-    |};
-      ( "sqlalchemy_1_4/ext/declarative/__init__.pyi",
-        {|
-            from .api import (
-                declarative_base as declarative_base,
-                DeclarativeMeta as DeclarativeMeta,
-            )
-          |}
-      );
-      ( "sqlalchemy_1_4/ext/declarative/api.pyi",
-        {|
-            def declarative_base(bind: Optional[Any] = ..., metadata: Optional[Any] = ...,
-                                 mapper: Optional[Any] = ..., cls: Any = ..., name: str = ...,
-                                 constructor: Any = ..., class_registry: Optional[Any] = ...,
-                                 metaclass: Any = ...): ...
-
-            class DeclarativeMeta(type):
-                def __init__(cls, classname, bases, dict_) -> None: ...
-                def __setattr__(cls, key, value): ...
-        |}
-      );
-    ]
-  in
   let torch_stubs =
     [
       ( "torch/__init__.pyi",
@@ -2639,7 +2612,6 @@ let typeshed_stubs ?(include_helper_builtins = true) () =
         |};
   ]
   @ sqlalchemy_stubs
-  @ sqlalchemy_1_4_stubs
   @ torch_stubs
 
 


### PR DESCRIPTION
Summary: Let's remove the workarounds we had added previously for sqlalchemy version migration.

Differential Revision: D33483940

