### PR TITLE
Fix OSS build: unittest.mock is more limited in < 3.8

### DIFF
--- a/client/commands/tests/persistent_test.py
+++ b/client/commands/tests/persistent_test.py
@@ -1016,10 +1016,18 @@ def patch_connect_in_text_mode(
     input_channel: TextReader, output_channel: TextWriter
 ) -> Iterator[CallableMixin]:
     with patch.object(async_server_connection, "connect_in_text_mode") as mock:
-        mock.return_value.__aenter__.return_value = (
-            input_channel,
-            output_channel,
-        )
+
+        class MockedConnection:
+            async def __aenter__(self):
+                return (
+                    input_channel,
+                    output_channel,
+                )
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        mock.return_value = MockedConnection()
         yield mock
 
 


### PR DESCRIPTION
Summary:
We recently added unit test code that reaches into a MagicMock's
`__aenter__` attribute, and treats a mock as always a valid
context manager.

This works in Python 3.8+, but not in 3.6 and 3.7 so our OSS build
broke. In this commit, I instead set the return value to a manually
written async context manager.

I verified locally that this fix works but I'll also export to github
and check that we get clean results before landing.

Reviewed By: kbansal

Differential Revision: D34275880

