### PR TITLE
Adding Explain Like I'm 5 videos to the home page 

### DIFF
--- a/documentation/website/src/pages/index.js
+++ b/documentation/website/src/pages/index.js
@@ -79,6 +79,43 @@ function Feature({imageUrl, title, description}) {
   );
 }
 
+function VideoContainer() {
+  return (
+    <div className="container text--center margin-bottom--xl">
+      <div className="row">
+        <div className="col">
+          <h2>Brief Introduction into Pyre</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/k_xElpxw9aY"
+              title="Explain Like I'm 5: Pyre"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+        <div className="col">
+          <h2>Brief Introduction into Pysa</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/LDxAczqkBiY"
+              title="Explain Like I’m 5: Pysa"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
@@ -104,6 +141,7 @@ function Home() {
         </div>
       </header>
       <main>
+      <VideoContainer />
         {features && features.length && (
           <section className={styles.features}>
             <div className="container">

--- a/documentation/website/src/pages/index.js
+++ b/documentation/website/src/pages/index.js
@@ -84,7 +84,7 @@ function VideoContainer() {
     <div className="container text--center margin-bottom--xl">
       <div className="row">
         <div className="col">
-          <h2>Brief Introduction into Pyre</h2>
+          <h2>Brief Introduction to Pyre</h2>
           <div>
             <iframe
               width="560"
@@ -98,7 +98,7 @@ function VideoContainer() {
           </div>
         </div>
         <div className="col">
-          <h2>Brief Introduction into Pysa</h2>
+          <h2>Brief Introduction to Pysa</h2>
           <div>
             <iframe
               width="560"


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc..

## Test Plan
Here is a screenshot in how it looks:
![image](https://user-images.githubusercontent.com/12485205/154383148-e5a5c77a-bf22-4dcb-a301-74b0dd304cfc.png)
