### PR TITLE
Exclude playground in a less brittle way

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -4,12 +4,11 @@
     ".*/generate_taint_models/.*",
     ".*/scripts/.*",
     ".*/source/.*",
-    ".*/pyre-check/stubs/.*"
+    ".*/pyre-check/stubs/.*",
   ],
   "ignore_all_errors": [
     "client/tests/configuration_test.py",
-    "pyre_extensions/safe_json.py",
-    "tools/sandbox/application.py"
+    "pyre_extensions/safe_json.py"
   ],
   "search_path": [
     {


### PR DESCRIPTION
Summary:
By renaming the external try-pyre backend from "sandbox" to "playground",
I broke external CI.

Also, I realized the way we were suppressing errors is pretty brittle - may be
moving the playground code around a bit as I prep for PyCon, and I thin it would
be better to just exclude the full directory than to hardcode the exact path to the
module.

Differential Revision: D34312741

