### PR TITLE
make announcementBarContent change style (mobile)

### DIFF
--- a/documentation/website/src/css/custom.css
+++ b/documentation/website/src/css/custom.css
@@ -92,13 +92,13 @@ div[class^="announcementBarContent"] a:hover {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Website's banner is not properly selected using `.announcement` as it's actual class is `.announcementBarContent_3EUC`.
`.announcement` should be `div[class^="announcementBarContent"]`.

## Screenshots
![pyre-check org_](https://user-images.githubusercontent.com/78584173/166887706-a0e53358-6e0d-4842-b3f9-0cc396a25207.png)

