### PR TITLE
Upgrade to black 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,5 +8,5 @@ repos:
   hooks:
     - id: ufmt
       additional_dependencies:
-        - black == 21.4b2
+        - black == 22.3.0
         - usort == 0.6.4


### PR DESCRIPTION
Matches the new internal version.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
    - [x] `pre-commit run`

## Summary

The version of black was upgraded internally and synced in e365c600e992f79b17cb73993b755d911f71029b

This updates the pre-commit hook to make sure formatting matches.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
jreese@butterfree ~/workspace/pyre-check main± » pre-commit run -a
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

client/configuration/tests/configuration_test.py:6:1: F401 'dataclasses' imported but unused
client/configuration/tests/configuration_test.py:15:1: F401 'typing.Optional' imported but unused
client/configuration/tests/configuration_test.py:31:1: F401 '..configuration.merge_partial_configurations' imported but unused

Format files with µfmt...................................................Passed
```
