### PR TITLE
Handle non-unicode binary data in the client

### DIFF
--- a/client/commands/analyze.py
+++ b/client/commands/analyze.py
@@ -210,6 +210,7 @@ def _run_analyze_command(
                 stdout=subprocess.PIPE,
                 stderr=log_file.file,
                 universal_newlines=True,
+                errors="replace",
             )
             return_code = result.returncode
 

--- a/client/commands/check.py
+++ b/client/commands/check.py
@@ -162,6 +162,7 @@ def _run_check_command(command: Sequence[str], output: str) -> commands.ExitCode
                 stdout=subprocess.PIPE,
                 stderr=log_file.file,
                 universal_newlines=True,
+                errors="replace",
             )
             return_code = result.returncode
 

--- a/client/commands/infer.py
+++ b/client/commands/infer.py
@@ -807,6 +807,7 @@ def _run_infer_command_get_output(command: Sequence[str]) -> str:
                 stdout=subprocess.PIPE,
                 stderr=log_file.file,
                 universal_newlines=True,
+                errors="replace",
             )
             return_code = result.returncode
 

--- a/client/commands/server_connection.py
+++ b/client/commands/server_connection.py
@@ -93,6 +93,14 @@ def connect_in_text_mode(
     """
     with connect(socket_path) as (input_channel, output_channel):
         yield (
-            io.TextIOWrapper(input_channel, encoding="utf-8", line_buffering=True),
-            io.TextIOWrapper(output_channel, encoding="utf-8", line_buffering=True),
+            io.TextIOWrapper(
+                input_channel,
+                line_buffering=True,
+                errors="replace",
+            ),
+            io.TextIOWrapper(
+                output_channel,
+                line_buffering=True,
+                errors="replace",
+            ),
         )


### PR DESCRIPTION
Summary:
The ocaml backend of pyre works with bytestrings. This
in itself isn't a problem - there's nothing inherently
wrong with using bytestrings for string-or-binary data,
in fact that's what shiny new parser libraries like
tree-sitter do.

But we have to be careful when we send that data over the
wire; Python wants to consume it as json, whcih has to be
valid unicode (which we'll try to get using the default
encoding utf-8).

For the vast majority of python files, variable names and
strings are utf-8 so naively sending the ocaml bytestrings
over works fine.

But there are a few edge cases where things go wrong:
- for certain, a bytes literal in python - even a utf-8 encoded
  module - will parse into an ocaml byte string that is not
  valid. This is because when CPython parses a bytes literal,
  the resulting AST node does not contain the string representing
  those bytes, it contains the bytes themselves (which may not be
  a valid encoding)
- it's possible that a unicode string literal in an (e.g.) latin-1
  module might wind up being latin-1 encoded in ocaml. I'm
  actually unsure whether this happens; CPython's parser very
  likely will utf-8 encode for us.

Differential Revision: D37211803

