### PR TITLE
Fix Import Issue on Github Pyre check

### DIFF
--- a/client/commands/tests/language_server_protocol_test.py
+++ b/client/commands/tests/language_server_protocol_test.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Callable, Mapping, Optional, TypeVar
 
 import testslide
-from tools.pyre.client.commands.language_server_protocol import ContentChange
 
 from ... import json_rpc
 from ...tests import setup
@@ -20,6 +19,7 @@ from ..async_server_connection import (
 )
 from ..language_server_protocol import (
     ClientCapabilities,
+    ContentChange,
     DiagnosticTag,
     DidChangeTextDocumentParameters,
     DidCloseTextDocumentParameters,


### PR DESCRIPTION
Summary: Context: Using absolute import causes tests on the Github version of pyre check to fail. Changing the path from absolute path to relative path will fix this issue.

Differential Revision: D38129605

