### PR TITLE
Implement caching

### DIFF
--- a/tools/playground/system/playground.service
+++ b/tools/playground/system/playground.service
@@ -9,6 +9,7 @@ WorkingDirectory=/home/ubuntu/playground
 Environment="PATH=/home/ubuntu/play-env/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Environment="PYSA_PLAYGROUND_STUBS=/home/ubuntu/pyre-check/stubs"
 Environment="PYSA_PLAYGROUND_TAINT_MODELS=/home/ubuntu/pyre-check/stubs/taint"
+Environment="PYSA_PLAYGROUND_CACHE_DIRECTORY=/var/pysa_cache/"
 ExecStart=/home/ubuntu/play-env/bin/gunicorn --workers 10 --timeout 120 --bind 127.0.0.1:5000 wsgi:application
 StandardOutput=file:/var/log/playground.out
 StandardError=file:/var/log/playground.err


### PR DESCRIPTION
Summary:
Implements caching in pysa playground to return the same response when a same model and code is being used.

A md5 hash is computed on the concatenated model and code input which serves as a file name for a cache file which stores the output of Pysa for that speicifc pair of input.

Adds code to create cache when we don't have cache and to use cache when we have it.

Signed-off-by: Abishek V Ashok <abishekvashok@fb.com>

Differential Revision: D38859999

