### PR TITLE
Add a debug step to the pyre workflow

### DIFF
--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -24,6 +24,11 @@ jobs:
           VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
           pip install pyre-check-nightly==$VERSION
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-actor: true
+
       - name: Run Pyre
         continue-on-error: true
         run: |


### PR DESCRIPTION
The version of pyre-check-nightly that is failing to run in CI
(not just for us, but also for torchx) appears to work just fine
on my machine. I think I need to get in and poke around to
determine what is happening.

There may be other ways to debug, but if this works and I can get
an interactive shell inside the instance then that will probably
be a faster way to debug.
