### PR TITLE
Send lines to highlight in trace [trace viewing 1/2]

### DIFF
--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -50,3 +50,7 @@ jobs:
           cd ./documentation/deliberately_vulnerable_flask_app
           . ./setup.sh
           ./run_integration_tests.sh
+
+      - name: Test Pysa playground
+        run: |
+          python3 ./tools/playground/tests/taint_output_parse_test.py

--- a/documentation/deliberately_vulnerable_flask_app/run_integration_tests.sh
+++ b/documentation/deliberately_vulnerable_flask_app/run_integration_tests.sh
@@ -7,7 +7,8 @@
 set +e
 python3 ../../tools/pysa_integration_tests/run.py \
     --skip-model-verification \
-    --run-from-source
+    --run-from-source \
+    --save-results-to=./
 
 exit_code=$?
 

--- a/tools/playground/tests/taint_output_parse_test.py
+++ b/tools/playground/tests/taint_output_parse_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import unittest
+from pathlib import Path
+
+from ..application import _parse_annotations_from_taint_output
+
+
+class TestTaintOutputParser(unittest.TestCase):
+    def test_parser(self):
+        expected_output = {}
+        expected_output_file_path = Path(
+            os.getcwd() / "taint_output_parsed.expected.json"
+        )
+        self.assertTrue(
+            expected_output_file_path.exists() and expected_output_file_path.is_file()
+        )
+        with expected_output_file_path.open() as expected_output_file:
+            expected_output_file = json.loads(expected_output_file.read())
+        taint_output_file_path = Path(os.getcwd() / "taint_output.json")
+        self.assertTrue(
+            taint_output_file_path.exists() and taint_output_file_path.is_file()
+        )
+        self.assertEqual(
+            _parse_annotations_from_taint_output(taint_output_file_path),
+            expected_output,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Adds feature in Pysa playground to view trace. After computation of taint-output.json file, send the results to Pysa frontend.

Modifies existing cache approach to make it more modular and add support for caching annotations as well.

Adds Github actions CI tests (in existing pysa action) to make sure the code for parsing the taint_config doesn't go out of date as the format of taint-output.json changes often. Existing pysa test was used because it already runs pysa from source code on `delibrately_vulnerable_flask_app`, and adding a same action with just few more lines to the pysa test doesn't really make much sense.

Signed-off-by: Abishek V Ashok <abishekvashok@fb.com>

Differential Revision: D38980480

