### PR TITLE
Add support for Self in non-self/cls params

### DIFF
--- a/source/analysis/test/integration/typeVariableTest.ml
+++ b/source/analysis/test/integration/typeVariableTest.ml
@@ -3812,6 +3812,38 @@ let test_self_type context =
        (bound to Shape)]]`.";
       "Revealed type [-1]: Revealed type for `circle` is `Circle`.";
     ];
+  assert_type_errors
+    {|
+      from typing_extensions import Self
+
+      class HasEqual:
+        def __eq__(self, other: Self) -> bool:
+          reveal_type(self)
+          reveal_type(other)
+          return True
+     |}
+    [
+      "Revealed type [-1]: Revealed type for `self` is `Variable[_Self_test_HasEqual__ (bound to \
+       HasEqual)]`.";
+      "Revealed type [-1]: Revealed type for `other` is `Variable[_Self_test_HasEqual__ (bound to \
+       HasEqual)]`.";
+    ];
+  assert_type_errors
+    {|
+      from typing_extensions import Self
+
+      class Merger:
+        def merge(self, other: Self) -> Self:
+          reveal_type(self)
+          reveal_type(other)
+          return self
+     |}
+    [
+      "Revealed type [-1]: Revealed type for `self` is `Variable[_Self_test_Merger__ (bound to \
+       Merger)]`.";
+      "Revealed type [-1]: Revealed type for `other` is `Variable[_Self_test_Merger__ (bound to \
+       Merger)]`.";
+    ];
   ()
 
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Pyre mostly supports `Self` types, but not in parameter positions that are not the first parameter (as `self` or `cls`).

This adds support for patterns where an object of the current type needs to be passed in and the class has children:

```py
class Base:
  def merge(self, other: Self) -> Self:
    ...
    return self

class Child(Base):
    pass
```


This PR adds support and appropriate unit test coverage. I’ve never written ocaml before and it probably shows, I’ll happily take feedback on code style.

## Test Plan

`make test` passes (with new test cases)

Fixes: https://github.com/facebook/pyre-check/issues/660
