### PR TITLE
Fix drop support for Python 3.6

### DIFF
--- a/scripts/pypi/setup.py
+++ b/scripts/pypi/setup.py
@@ -117,7 +117,7 @@ def run(
         + get_all_files(root=Path.cwd() / "stubs/lxml", extension_glob="*.pyi")
         + get_all_files(root=Path.cwd() / "pysa_filters", extension_glob="*.json")
         + find_taint_stubs(),
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         install_requires=runtime_dependencies,
         entry_points=dict(  # noqa we need to do this to make this .format-able
             console_scripts=[


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Previous drop of support for Python 3.6 did not update `setup.py` correctly so PyPI still thinks pyre-check 0.9.16 is still compatible with Python 3.6.
This should fix the issue for future versions but, as stated in #671, the issue remains for the already released 0.9.16

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
