### PR TITLE
[wip] Display line numbers in rule code duplicacy errors

### DIFF
--- a/source/interprocedural_analyses/taint/taintConfiguration.mli
+++ b/source/interprocedural_analyses/taint/taintConfiguration.mli
@@ -115,7 +115,11 @@ module Error : sig
         labels: string list;
       }
     | InvalidMultiSink of string
-    | RuleCodeDuplicate of int
+    | RuleCodeDuplicate of {
+        code: int;
+        previous_location: string;
+        current_location: string;
+      }
     | OptionDuplicate of string
     | SourceDuplicate of string
     | SinkDuplicate of string


### PR DESCRIPTION
Adds line number support to taint.config parser to report line numbers along with the duplicate code errors and hence make the errors typed.

YoJSON, the currently used JSON parsing module doesn't support line number parsing and has commented out the line number information provided to it by the lexing module and hence the patch file to re-enable it.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Co-authored-by: an onion <onionymous@users.noreply.github.com>
Fixes part of https://github.com/MLH-Fellowship/pyre-check/issues/82

Derived from discussions with @0xedward following: https://github.com/facebook/pyre-check/pull/549

## Test Plan

Apply this patch file and then run pysa with duplicate rule in taint.config file (or multiple files)

## Patch file

@0xedward how to apply this patch file and is the pyre-check team okay with having this is a question :)
```
diff --git a/lib/read.mll b/lib/read.mll
index 3e7a4d2..b1bd156 100644
--- a/lib/read.mll
+++ b/lib/read.mll
@@ -12,13 +12,11 @@
 
     let engine tbl state buf =
       let result = c_engine tbl state buf in
-      (*
       if result >= 0 then begin
         buf.lex_start_p <- buf.lex_curr_p;
         buf.lex_curr_p <- {buf.lex_curr_p
                            with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
       end;
-      *)
       result
   end
 ```