### PR TITLE
Support generic Self type

### DIFF
--- a/source/analysis/postprocessing.ml
+++ b/source/analysis/postprocessing.ml
@@ -17,11 +17,10 @@ module Error = AnalysisError
    by one, and remove the used codes from the map of unused ignores. Since the hash tables are
    initialized with only the sources we're considering, this is sufficient to determine all ignored
    errors and unused ignores. *)
-let handle_ignores_and_fixmes
-    ~qualifier
-    { Source.typecheck_flags = { Source.TypecheckFlags.ignore_lines; _ }; _ }
-    errors
-  =
+let handle_ignores_and_fixmes ~qualifier source errors =
+  let { Source.typecheck_flags = { Source.TypecheckFlags.ignore_lines; _ }; _ } =
+    Preprocessing.preprocess_phase1 source
+  in
   let unused_ignores, ignore_lookup =
     let unused_ignores = Location.Table.create () in
     let ignore_lookup = Int.Table.create () in

--- a/source/analysis/test/integration/typeVariableTest.ml
+++ b/source/analysis/test/integration/typeVariableTest.ml
@@ -3769,8 +3769,6 @@ let test_self_type context =
         concrete.set_value("bad")
      |}
     [
-      (* TODO(T103918696): Don't complain about the synthetic TypeVar bound. *)
-      "Invalid type parameters [24]: Generic type `Container` expects 1 type parameter.";
       "Revealed type [-1]: Revealed type for `self` is `Variable[_Self_test_Container__ (bound to \
        Container[typing.Any])]`.";
       "Revealed type [-1]: Revealed type for `y` is `ChildContainer[str]`.";


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Basically, enable this example code to work:

```python3
# pyre-strict

from typing import Generic, Self, TypeVar

T = TypeVar("T")

class Foo(Generic[T]):
    def __init__(self, t: T) -> None:
        pass

    def get_self(self) -> Self:
        return Self
```

Before this change, this returns:

`Invalid type parameters [24]: Generic type Foo expects 1 type parameter.`

After, there are no errors reported.

## Test Plan

Ran the test suite, including the updated tests. I also ran on a private project that uses generic Self and no errors were reported.

Fixes: https://github.com/facebook/pyre-check/issues/659
