### PR TITLE
Support typing.TypeAlias in addition to typing_extensions.TypeAlias

### DIFF
--- a/source/analysis/aliasEnvironment.ml
+++ b/source/analysis/aliasEnvironment.ml
@@ -230,7 +230,7 @@ let extract_alias unannotated_global_environment name ~dependency =
                   Name
                     (Name.Attribute
                       {
-                        base = { Node.value = Name (Name.Identifier "typing_extensions"); _ };
+                        base = { Node.value = Name (Name.Identifier ("typing_extensions" | "typing")); _ };
                         attribute = "TypeAlias";
                         _;
                       });

--- a/source/analysis/missingFromStubs.ml
+++ b/source/analysis/missingFromStubs.ml
@@ -236,6 +236,7 @@ let missing_typing_classes =
     make "typing.ClassMethod" ~bases:single_unary_generic ~body:classmethod_body;
     make "typing.StaticMethod" ~bases:single_unary_generic ~body:staticmethod_body;
     make "typing.GenericMeta" ~bases:[Primitive "type"] ~body:generic_meta_body;
+    make "typing.TypeAlias";
     make "typing.TypeGuard" ~bases:(Type.bool :: single_unary_generic);
     make "typing.Required" ~bases:single_unary_generic;
     make "typing.NotRequired" ~bases:single_unary_generic;

--- a/source/analysis/test/integration/annotationTest.ml
+++ b/source/analysis/test/integration/annotationTest.ml
@@ -328,6 +328,13 @@ let test_check_invalid_type context =
   assert_type_errors
     {|
       import typing
+      MyType: typing.TypeAlias = int
+      x: MyType = 1
+    |}
+    [];
+  assert_type_errors
+    {|
+      import typing
       # Type aliases cannot be annotated
       MyType: typing.Type[int] = int
       x: MyType = 1


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Python's standard library has offered `typing.TypeAlias` since 3.10. Specifically, this commit: https://github.com/python/cpython/commit/4f3c25043d651a13c41cffcee703f7d5cb677cc7

Ref: https://peps.python.org/pep-0613/

Note that the `typing_extensions` class merely re-exports `TypeAlias` from the stdlib when running on a version of python that has `TypeAlias` in `typing`: https://github.com/python/typing_extensions/blob/main/src/typing_extensions.py#L1110-L1112

## Test Plan

Added unit test case, and tested against a private python codebase.