### PR TITLE
Fix broken github build - pysa.yml needs 5.0.0

### DIFF
--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Setup OCaml
         uses: avsm/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.14.0
+          ocaml-compiler: 5.0.0
 
       - name: Setup opam switch
         run: |
-          opam switch create 4.14.0
-          echo "OPAM_SWITCH_PREFIX=$HOME/.opam/4.14.0" >> $GITHUB_ENV
-          echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/4.14.0/lib/stublibs:$HOME/.opam/4.14.0/lib/ocaml/stublibs:$HOME/.opam/4.14.0/lib/ocam" >> $GITHUB_ENV
-          echo "$HOME/.opam/4.14.0/bin" >> $GITHUB_PATH
-          echo "/home/opam/.opam/4.14.0/bin" >> $GITHUB_PATH
+          opam switch create 5.0.0
+          echo "OPAM_SWITCH_PREFIX=$HOME/.opam/5.0.0" >> $GITHUB_ENV
+          echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/5.0.0/lib/stublibs:$HOME/.opam/5.0.0/lib/ocaml/stublibs:$HOME/.opam/5.0.0/lib/ocam" >> $GITHUB_ENV
+          echo "$HOME/.opam/5.0.0/bin" >> $GITHUB_PATH
+          echo "/home/opam/.opam/5.0.0/bin" >> $GITHUB_PATH
 
       - name: Build Pyre (and Pysa)
         run: |


### PR DESCRIPTION
Summary:
Unfortunately it is easy to forget to bump the compiler version
in the github action; I forgot to do so last week.

This should fix our red github signal

Differential Revision: D42480670

