### PR TITLE
Back Pyre off to Ocaml 4.14.0

### DIFF
--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Setup OCaml
         uses: avsm/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.0.0
+          ocaml-compiler: 4.14.0
 
       - name: Setup opam switch
         run: |
-          opam switch create 5.0.0
-          echo "OPAM_SWITCH_PREFIX=$HOME/.opam/5.0.0" >> $GITHUB_ENV
-          echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/5.0.0/lib/stublibs:$HOME/.opam/5.0.0/lib/ocaml/stublibs:$HOME/.opam/5.0.0/lib/ocam" >> $GITHUB_ENV
-          echo "$HOME/.opam/5.0.0/bin" >> $GITHUB_PATH
-          echo "/home/opam/.opam/5.0.0/bin" >> $GITHUB_PATH
+          opam switch create 4.14.0
+          echo "OPAM_SWITCH_PREFIX=$HOME/.opam/4.14.0" >> $GITHUB_ENV
+          echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/4.14.0/lib/stublibs:$HOME/.opam/4.14.0/lib/ocaml/stublibs:$HOME/.opam/4.14.0/lib/ocam" >> $GITHUB_ENV
+          echo "$HOME/.opam/4.14.0/bin" >> $GITHUB_PATH
+          echo "/home/opam/.opam/4.14.0/bin" >> $GITHUB_PATH
 
       - name: Build Pyre (and Pysa)
         run: |

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Mapping, NamedTuple, Optional, Type
 LOG: logging.Logger = logging.getLogger(__name__)
 
 
-COMPILER_VERSION = "5.0.0"
+COMPILER_VERSION = "4.14.0"
 DEPENDENCIES = [
     "base64.3.5.0",
     "core.v0.15.1",


### PR DESCRIPTION
Summary:
After more extensive investigation the Hack team has
realized that the current logic in Ocamlrep is tied to the Ocaml 4
runtime in ways that will take time to migrate.

Unfortunately, this means Pyre can only have one in the short term:
Ocamlrep-based Errpy integration or Ocaml 5.0. Given that Errpy is
an immeidate blocker for IDE work, whereas Ocaml 5.0 is mostly a
BE win and a potential blocker for perf problems, the right
move for now is probably to back off.

The good news is that there was a great deal of other work
(library upgrades, fixing use of deprecated names in the standard libary,
etc) that we had to do to be Ocaml 5.0 ready, and that is all done.

So if multiprocessing / serialization - related perf overhead become
a top concern, we can either do a sprint on ocamlrep or find an
alternative (e.g. wrap Errpy in C and use a hand-written binder like
Jia did for CPython) and move back to 5.0

Differential Revision: D42805249

