### PR TITLE
Adds support for checking python version in models

### DIFF
--- a/documentation/website/docs/pysa_advanced.md
+++ b/documentation/website/docs/pysa_advanced.md
@@ -6,6 +6,33 @@ sidebar_label: Advanced Topics
 
 This page documents less straightforward bits of Pysa.
 
+## Conditional models based on Python version
+
+Pysa models support if conditions but only for version comparisons for the python
+version used to run pysa. This allows for conditional parsing of models and allows
+different models to be used for different versions of python.
+
+```python
+if sys.version == (3,9,0):
+    def module.foo(): ...
+else:
+    def module.bar(): ...
+```
+In this example, the first model will only be parsed and honoured if the python
+version in the system or virtual environment from which Pysa is run is equal
+to "3.9.0". In all other conditions, the second model will be parsed and honoured.
+
+sys.version is the only allowed left hand expression and the right hand expression
+has to be a tuple of integers of the form (major, minor, micro). Only the major
+version number is required and the other two are optional.
+
+The comparison operators supported include '==' (equal to), '!=' (not equal to),
+'&lt;' (less than), '&gt;' greater than, '&lt;=' (less than or equal to), and
+'&gt;=' (greater than or equal to).
+
+If conditions can also be nested inside one another and follow the same behavior
+as python if conditions.
+
 ## Obscure models
 
 When Pysa does not have enough information about a function or method, it will

--- a/source/configuration.ml
+++ b/source/configuration.ml
@@ -233,7 +233,7 @@ module PythonVersion = struct
     minor: int;
     micro: int;
   }
-  [@@deriving sexp, compare, hash, yojson]
+  [@@deriving sexp, compare, hash, yojson, equal]
 
   let default =
     {

--- a/source/configuration.mli
+++ b/source/configuration.mli
@@ -73,7 +73,7 @@ module PythonVersion : sig
     minor: int;
     micro: int;
   }
-  [@@deriving sexp, compare, hash, yojson]
+  [@@deriving sexp, compare, hash, yojson, equal]
 
   val default : t
 end

--- a/source/interprocedural_analyses/taint/modelParser.mli
+++ b/source/interprocedural_analyses/taint/modelParser.mli
@@ -5,6 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+module PythonVersion : sig
+  include module type of Configuration.PythonVersion
+
+  val parse_from_tuple : Ast.Expression.Expression.t list -> (t, string) result
+
+  val from_configuration : Configuration.Analysis.t -> t
+
+  val compare_with
+    :  t ->
+    Ast.Expression.ComparisonOperator.operator ->
+    t ->
+    (bool, Ast.Expression.ComparisonOperator.operator) result
+end
+
 val get_model_sources : paths:PyrePath.t list -> (PyrePath.t * string) list
 
 val parse
@@ -15,6 +29,7 @@ val parse
   source_sink_filter:SourceSinkFilter.t option ->
   callables:Interprocedural.Target.HashSet.t option ->
   stubs:Interprocedural.Target.HashSet.t ->
+  python_version:PythonVersion.t ->
   unit ->
   ModelParseResult.t
 

--- a/source/interprocedural_analyses/taint/modelVerificationError.ml
+++ b/source/interprocedural_analyses/taint/modelVerificationError.ml
@@ -125,6 +125,9 @@ type kind =
   | UnsupportedClassConstraintCallee of Expression.t
   | UnsupportedDecoratorConstraint of Expression.t
   | UnsupportedDecoratorConstraintCallee of Expression.t
+  | UnsupportedIfCondition of Expression.t
+  | UnsupportedVersionConstant of string
+  | UnsupportedComparisonOperator of Expression.ComparisonOperator.operator
   | DeprecatedConstraint of {
       deprecated: string;
       suggested: string;
@@ -404,6 +407,16 @@ let description error =
         (Expression.show constraint_name)
   | UnsupportedDecoratorConstraintCallee callee ->
       Format.sprintf "Unsupported callee for decorator constraint: `%s`" (Expression.show callee)
+  | UnsupportedIfCondition condition ->
+      Format.sprintf
+        "Unsupported if condition: `%s`. If conditions need to be of the form: `sys.version \
+         operator version_tuple`. All models inside the if-block (along with those in else-if and \
+         else block, if present) will be ignored."
+        (Expression.show condition)
+  | UnsupportedVersionConstant error ->
+      Format.sprintf "Unsupported element type in version tuple in if condition: %s" error
+  | UnsupportedComparisonOperator operator ->
+      Format.asprintf "The operator `%a` in the if condition is not supported" Expression.ComparisonOperator.pp_comparison_operator operator
   | DeprecatedConstraint { deprecated; suggested } ->
       Format.sprintf "Constraint `%s` is deprecated, use `%s` instead." deprecated suggested
   | UnsupportedFindClause clause -> Format.sprintf "Unsupported find clause `%s`" clause
@@ -563,6 +576,9 @@ let code { kind; _ } =
   | ModelQueryDuplicateParameter _ -> 65
   | InvalidModelQueryNameClause _ -> 66
   | NoOutputFromModelQueryGroup _ -> 67
+  | UnsupportedIfCondition _ -> 68
+  | UnsupportedVersionConstant _ -> 69
+  | UnsupportedComparisonOperator _ -> 70
 
 
 let display { kind = error; path; location } =

--- a/source/interprocedural_analyses/taint/modelVerificationError.mli
+++ b/source/interprocedural_analyses/taint/modelVerificationError.mli
@@ -121,6 +121,9 @@ type kind =
   | UnsupportedClassConstraintCallee of Expression.t
   | UnsupportedDecoratorConstraint of Expression.t
   | UnsupportedDecoratorConstraintCallee of Expression.t
+  | UnsupportedIfCondition of Expression.t
+  | UnsupportedVersionConstant of string
+  | UnsupportedComparisonOperator of Expression.ComparisonOperator.operator
   | DeprecatedConstraint of {
       deprecated: string;
       suggested: string;

--- a/source/interprocedural_analyses/taint/taintAnalysis.ml
+++ b/source/interprocedural_analyses/taint/taintAnalysis.ml
@@ -140,6 +140,7 @@ let parse_models_and_queries_from_sources
     ~source_sink_filter
     ~callables
     ~stubs
+    ~python_version
     sources
   =
   (* TODO(T117715045): Do not pass all callables and stubs explicitly to map_reduce,
@@ -155,6 +156,7 @@ let parse_models_and_queries_from_sources
           ~source_sink_filter:(Some source_sink_filter)
           ~callables
           ~stubs
+          ~python_version
           ()
         |> ModelParseResult.join state)
   in
@@ -176,15 +178,20 @@ let parse_models_and_queries_from_sources
 let parse_models_and_queries_from_configuration
     ~scheduler
     ~static_analysis_configuration:
-      { Configuration.StaticAnalysis.verify_models; configuration = { taint_model_paths; _ }; _ }
+      {
+        Configuration.StaticAnalysis.verify_models;
+        configuration;
+        _;
+      }
     ~taint_configuration
     ~resolution
     ~source_sink_filter
     ~callables
     ~stubs
   =
+  let python_version = ModelParser.PythonVersion.from_configuration configuration in
   let ({ ModelParseResult.errors; _ } as parse_result) =
-    ModelParser.get_model_sources ~paths:taint_model_paths
+    ModelParser.get_model_sources ~paths:(configuration.taint_model_paths)
     |> parse_models_and_queries_from_sources
          ~taint_configuration
          ~scheduler
@@ -192,6 +199,7 @@ let parse_models_and_queries_from_configuration
          ~source_sink_filter
          ~callables
          ~stubs
+         ~python_version
   in
   let () = ModelVerificationError.verify_models_and_dsl errors verify_models in
   parse_result

--- a/source/interprocedural_analyses/taint/test/forwardAnalysisTest.ml
+++ b/source/interprocedural_analyses/taint/test/forwardAnalysisTest.ml
@@ -46,6 +46,7 @@ let assert_taint ?models ?models_source ~context source expect =
         ~source_sink_filter:None
         ~callables:None
         ~stubs:(Target.HashSet.create ())
+        ~python_version:ModelParser.PythonVersion.default
         ()
     in
     let () = assert_bool "Error while parsing models." (List.is_empty errors) in

--- a/source/interprocedural_analyses/taint/test/testHelper.ml
+++ b/source/interprocedural_analyses/taint/test/testHelper.ml
@@ -428,6 +428,7 @@ let get_initial_models ~context =
       ~source_sink_filter:None
       ~callables:None
       ~stubs:(Target.HashSet.create ())
+      ~python_version:ModelParser.PythonVersion.default
       ()
   in
   assert_bool
@@ -553,6 +554,7 @@ let initialize
             ~source_sink_filter:(Some taint_configuration.source_sink_filter)
             ~callables:(Some (Target.HashSet.of_list callables))
             ~stubs:(Target.HashSet.of_list stubs)
+            ~python_version:ModelParser.PythonVersion.default
             ()
         in
         assert_bool

--- a/source/server/query.ml
+++ b/source/server/query.ml
@@ -1075,6 +1075,9 @@ let rec process_request ~type_environment ~build_system request =
           | Error (error :: _) -> Error (Taint.TaintConfiguration.Error.show error)
           | Error _ -> failwith "Taint.TaintConfiguration.create returned empty errors list"
           | Ok taint_configuration -> (
+              let python_version =
+                Taint.ModelParser.PythonVersion.from_configuration configuration
+              in
               let get_model_queries (path, source) =
                 Taint.ModelParser.parse
                   ~resolution:global_resolution
@@ -1084,6 +1087,7 @@ let rec process_request ~type_environment ~build_system request =
                   ~source_sink_filter:None
                   ~callables:None
                   ~stubs:(Interprocedural.Target.HashSet.create ())
+                  ~python_version
                   ()
                 |> fun { Taint.ModelParseResult.queries; errors; _ } ->
                 if List.is_empty errors then
@@ -1394,6 +1398,7 @@ let rec process_request ~type_environment ~build_system request =
           |> Taint.TaintConfiguration.exception_on_error
         in
         let get_model_errors_and_model_queries sources =
+          let python_version = Taint.ModelParser.PythonVersion.from_configuration configuration in
           let get_model_errors_and_model_queries (path, source) =
             Taint.ModelParser.parse
               ~resolution:global_resolution
@@ -1403,6 +1408,7 @@ let rec process_request ~type_environment ~build_system request =
               ~source_sink_filter:None
               ~callables:None
               ~stubs:(Interprocedural.Target.HashSet.create ())
+              ~python_version
               ()
             |> fun { Taint.ModelParseResult.errors; queries; _ } -> errors, queries
           in


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Adds support for checking python versions in pysa models by extending the model parser to parse if-conditions as well.

Previously all if-conditions in the modes file were discarded with a model verification error of type Unsupportedstatement. Extend the AST logic to check for the presence of if conditions and honour them. Currently, we can check against the python version in the system provided to the taintAnalysis Command and while running the server by accessing the configuration.

This allows us to write if conditions along with else if blocks if needed in model files of the form:
`if sys.version <operator> (<python_major_version>, <python_minor_version>, <python_micro_version>):`
The models in the if body or the else body will be parsed only if the condition evaluates to true. sys.version is the only allowed left hand expression, all other expressions lead to a model verification error.

Nesting of if conditions are also supported. All comparison operators except in and not in are supported. If the right side expression is not a tuple, the if condition is ignored and a model verification error is emitted.

Update existing tests and ModelParser.parse invocations to pass in the python_version. Adds new unit tests as well.

Also adds documentation for the same.

## Test Plan

- Build the project from source using dune
- cd a repository down
- For ease, modify the model in documentation/pysa_tutorials/exercise1 to add an if condition with a comparison operator to it, eg:
```
if sys.version < (2,1,0):
    django.http.request.HttpRequest.GET: TaintSource[CustomUserControlled] = ...
    def eval(__source: TaintSink[CodeExecution], __globals, __locals): ...
```
- Create the following .pyre_configuration file:
```
{
    "source_directories": ["pyre-check/documentation/pysa_tutorial/exercise1/"],
    "search_path": ["./stubs/stubs"],
    "taint_models_path": "./pyre-check/documentation/pysa_tutorial/exercise1/"
}
```
- run pysa and see that the model is not getting detected. (No issues):

<img width="1440" alt="Screenshot 2023-03-20 at 11 44 18 AM" src="https://user-images.githubusercontent.com/8947010/226263061-10e4d90c-819c-498b-a052-cad26e4627bf.png">


- change the model such that the if condition evaluates to true
```
if sys.version > (2,1,0):
    django.http.request.HttpRequest.GET: TaintSource[CustomUserControlled] = ...
    def eval(__source: TaintSink[CodeExecution], __globals, __locals): ...
```
- run pysa again and see that the model does get detected (1 issue found):


<img width="1440" alt="Screenshot 2023-03-20 at 11 45 13 AM" src="https://user-images.githubusercontent.com/8947010/226263166-31667fec-d07f-423a-adb8-de91d5def179.png">

- change the if condition to something else, for example, `if (2,1,0):` to see a model verification error:

<img width="1440" alt="Screenshot 2023-03-20 at 11 46 49 AM" src="https://user-images.githubusercontent.com/8947010/226263290-d6f8747e-fb5b-4113-a466-f154b629bbba.png">


- run pysa on delibrately_vulnerable_app to make sure this doesn't break anything (github action)
- unit tests and github actions

Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/83
