### PR TITLE
Remove typeguard version pin with TestSlide version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pyre-extensions>=0.0.29
 tabulate
 testslide>=2.7.0
 typing_extensions
-typeguard<3.0


### PR DESCRIPTION
Summary:
**Background**: Undoes temporary typeguard version pin from earlier broken tests. TestSlide made a release to do the pin for us, and they'll be working on an update to address the typeguard API change on their end.

**Context**: Pyre open source builds were failing, and I tracked down the issue to a recent major API change with typeguard, one of testslide's dependencies.

As a temporary fix, I pinned the version of typeguard we use to the version prior to the major update, which seems to have fixed the issue.

Differential Revision: D44142861

