### PR TITLE
Add position information to taint.config errors

### DIFF
--- a/client/command_arguments.py
+++ b/client/command_arguments.py
@@ -276,6 +276,7 @@ class AnalyzeArguments:
     maximum_trace_length: Optional[int] = None
     no_verify: bool = False
     verify_dsl: bool = False
+    verify_taint_configuration: bool = False
     output: str = TEXT
     repository_root: Optional[str] = None
     rule: List[int] = field(default_factory=list)

--- a/client/commands/analyze.py
+++ b/client/commands/analyze.py
@@ -56,6 +56,7 @@ class Arguments:
     maximum_trace_length: Optional[int] = None
     no_verify: bool = False
     verify_dsl: bool = False
+    verify_taint_configuration: bool = False
     repository_root: Optional[str] = None
     rule_filter: Optional[Sequence[int]] = None
     source_filter: Optional[Sequence[str]] = None
@@ -172,6 +173,7 @@ class Arguments:
             ),
             "no_verify": self.no_verify,
             "verify_dsl": self.verify_dsl,
+            "verify_taint_configuration": self.verify_taint_configuration,
             **({} if repository_root is None else {"repository_root": repository_root}),
             **({} if rule_filter is None else {"rule_filter": rule_filter}),
             **({} if source_filter is None else {"source_filter": source_filter}),
@@ -278,6 +280,7 @@ def create_analyze_arguments(
         maximum_trace_length=analyze_arguments.maximum_trace_length,
         no_verify=analyze_arguments.no_verify,
         verify_dsl=analyze_arguments.verify_dsl,
+        verify_taint_configuration=analyze_arguments.verify_taint_configuration,
         repository_root=repository_root,
         rule_filter=None if len(rule) == 0 else rule,
         source_filter=None if len(source) == 0 else source,

--- a/client/pyre.py
+++ b/client/pyre.py
@@ -409,6 +409,12 @@ def pyre(
     help="Verify DSL model queries for the taint analysis.",
 )
 @click.option(
+    "--verify-taint-configuration",
+    is_flag=True,
+    default=False,
+    help="Verify taint.config files. Skips analysis.",
+)
+@click.option(
     "--version",
     is_flag=True,
     default=False,
@@ -550,6 +556,7 @@ def analyze(
     taint_models_path: Iterable[str],
     no_verify: bool,
     verify_dsl: bool,
+    verify_taint_configuration: bool,
     version: bool,
     save_results_to: Optional[str],
     output_format: Optional[str],
@@ -613,6 +620,7 @@ def analyze(
             maximum_trace_length=maximum_trace_length,
             no_verify=no_verify,
             verify_dsl=verify_dsl,
+            verify_taint_configuration=verify_taint_configuration,
             output=command_argument.output,
             repository_root=repository_root,
             rule=list(rule),

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -35,6 +35,7 @@ DEPENDENCIES = [
     "core_unix.v0.15.2",
     "re2.v0.15.0",
     "dune.3.7.1",
+    "jsonm.1.0.2",
     "yojson.2.0.2",
     "ppx_deriving_yojson.3.7.0",
     "ppx_yojson_conv.v0.15.1",

--- a/source/command/analyzeCommand.mli
+++ b/source/command/analyzeCommand.mli
@@ -36,6 +36,7 @@ module AnalyzeConfiguration : sig
     maximum_tito_depth: int option;
     no_verify: bool;
     verify_dsl: bool;
+    verify_taint_configuration: bool;
     repository_root: PyrePath.t option;
     rule_filter: int list option;
     source_filter: string list option;

--- a/source/configuration.ml
+++ b/source/configuration.ml
@@ -520,6 +520,7 @@ module StaticAnalysis = struct
     dump_call_graph: PyrePath.t option;
     verify_models: bool;
     verify_dsl: bool;
+    verify_taint_configuration: bool;
     (* Analysis configuration *)
     configuration: Analysis.t;
     rule_filter: int list option;
@@ -553,6 +554,7 @@ module StaticAnalysis = struct
       ?dump_call_graph
       ?(verify_models = true)
       ?(verify_dsl = true)
+      ?(verify_taint_configuration = false)
       ?rule_filter
       ?source_filter
       ?sink_filter
@@ -583,6 +585,7 @@ module StaticAnalysis = struct
       dump_call_graph;
       verify_models;
       verify_dsl;
+      verify_taint_configuration;
       configuration;
       rule_filter;
       source_filter;

--- a/source/configuration.mli
+++ b/source/configuration.mli
@@ -232,6 +232,7 @@ module StaticAnalysis : sig
     dump_call_graph: PyrePath.t option;
     verify_models: bool;
     verify_dsl: bool;
+    verify_taint_configuration: bool;
     (* Analysis configuration *)
     configuration: Analysis.t;
     rule_filter: int list option;
@@ -265,6 +266,7 @@ module StaticAnalysis : sig
     ?dump_call_graph:PyrePath.t ->
     ?verify_models:bool ->
     ?verify_dsl:bool ->
+    ?verify_taint_configuration:bool ->
     ?rule_filter:int list ->
     ?source_filter:string list ->
     ?sink_filter:string list ->

--- a/source/interprocedural_analyses/taint/annotationParser.ml
+++ b/source/interprocedural_analyses/taint/annotationParser.ml
@@ -19,6 +19,9 @@ type taint_kind =
 type source_or_sink = {
   name: string;
   kind: taint_kind;
+  (* taint config positioning information *)
+  taint_config_position: string;
+  taint_config_path: PyrePath.t;
 }
 
 let parse_source ~allowed ?subkind name =

--- a/source/interprocedural_analyses/taint/annotationParser.mli
+++ b/source/interprocedural_analyses/taint/annotationParser.mli
@@ -12,6 +12,9 @@ type taint_kind =
 type source_or_sink = {
   name: string;
   kind: taint_kind;
+  (* taint config positioning information *)
+  taint_config_position: string;
+  taint_config_path: PyrePath.t;
 }
 
 val parse_source

--- a/source/interprocedural_analyses/taint/dune
+++ b/source/interprocedural_analyses/taint/dune
@@ -15,6 +15,7 @@
   core
   core_unix
   sexplib
+  jsonm
   yojson
   re2
   ppx_deriving_yojson

--- a/source/interprocedural_analyses/taint/rule.ml
+++ b/source/interprocedural_analyses/taint/rule.ml
@@ -18,6 +18,9 @@ type t = {
   code: int;
   name: string;
   message_format: string; (* format *)
+  (* taint config positioning information *)
+  taint_config_position: string;
+  taint_config_path: PyrePath.t;
 }
 [@@deriving compare, show]
 

--- a/source/interprocedural_analyses/taint/rule.mli
+++ b/source/interprocedural_analyses/taint/rule.mli
@@ -12,6 +12,9 @@ type t = {
   code: int;
   name: string;
   message_format: string; (* format *)
+  (* taint config positioning information *)
+  taint_config_position: string;
+  taint_config_path: PyrePath.t;
 }
 [@@deriving compare, show]
 

--- a/source/interprocedural_analyses/taint/taintAnalysis.mli
+++ b/source/interprocedural_analyses/taint/taintAnalysis.mli
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+val initialize_configuration
+  :  static_analysis_configuration:Configuration.StaticAnalysis.t ->
+  Taint.TaintConfiguration.Heap.t * Taint.TaintConfiguration.SharedMemory.t
+
 val run_taint_analysis
   :  static_analysis_configuration:Configuration.StaticAnalysis.t ->
   build_system:Server.BuildSystem.t ->

--- a/source/interprocedural_analyses/taint/taintConfiguration.mli
+++ b/source/interprocedural_analyses/taint/taintConfiguration.mli
@@ -144,12 +144,34 @@ module Error : sig
         labels: string list;
       }
     | InvalidMultiSink of string
-    | RuleCodeDuplicate of int
+    | RuleCodeDuplicate of {
+        code: int;
+        previous_position: string;
+        current_position: string;
+        previous_path: PyrePath.t;
+        current_path: PyrePath.t;
+      }
     | OptionDuplicate of string
-    | SourceDuplicate of string
-    | SinkDuplicate of string
+    | SourceDuplicate of {
+        name: string;
+        previous_position: string;
+        current_position: string;
+        previous_path: PyrePath.t;
+        current_path: PyrePath.t;
+      }
+    | SinkDuplicate of {
+        name: string;
+        previous_position: string;
+        current_position: string;
+        previous_path: PyrePath.t;
+        current_path: PyrePath.t;
+      }
     | TransformDuplicate of string
     | FeatureDuplicate of string
+    | JsonmParseError of {
+        message: string;
+        position: (int * int) * (int * int);
+      }
   [@@deriving equal, show]
 
   type t = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Add position information to taint.config validation errors - RuleCodeDuplicate, SourceDuplicate, SinkDuplicate.

Add an additional option to the analyze command called --verify-taint-configuration which just verifies the taint configuration and nothing more.

What makes this commit long and sturdy is mostly due to YoJSON, the current json file parser used to parse taint.config files, lack support for line numbers and column numbers of matched elements. This leaves us with two options:
1. Use another json parser which has support for getting line numbers
2. Get positioning information via hacky string operations

2. Has performance implications and for 1, the closest parser that does this is Jsonm, which has a complete lack of utility functions that yojson provide.

I opted for 1 and then converted the results to conform to the yojson data format, so that parsing is done only once and we get to use yojson's utility functions along with positioning information!

Why is this important? For our visual code extension, positioning information is vital.


## Test Plan

- Run `pyre -n analyze --verify-taint-configuration` on the `documentation/pysa_tutorial/exercise1/` with `taint.config` as follows:
```json
{
  "sources": [
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    },
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    }
  ],

  "sinks": [
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    },
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    }

  ],

  "features": [],

  "rules": [
    {
      "name": "Possible RCE:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    },
    {
      "name": "Possible RCEss:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    },
    {
      "name": "Possible RCEss:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    }
  ]
}
```

<img width="1151" alt="Screenshot 2023-04-21 at 7 03 03 PM" src="https://user-images.githubusercontent.com/8947010/233650353-55c18d6d-7d58-42d7-af2b-4f7d2f081c48.png">

- Run `pyre -n analyze --verify-taint-configuration` on the `documentation/pysa_tutorial/exercise1/` with `taint.config` changes reverted.

<img width="1151" alt="Screenshot 2023-04-21 at 7 03 50 PM" src="https://user-images.githubusercontent.com/8947010/233650426-04732382-8c63-4b77-b1d9-d6ec32ba6463.png">

- Run `pyre analyze` on the `documentation/pysa_tutorial/exercise1/` to make sure everything is working as before.

<img width="1151" alt="Screenshot 2023-04-21 at 7 08 03 PM" src="https://user-images.githubusercontent.com/8947010/233650462-ad151deb-162a-4269-be8c-17dad1212a00.png">

Fixes part of https://github.com/MLH-Fellowship/pyre-check/issues/82



