### PR TITLE
Adds verify taint config only option

### DIFF
--- a/client/command_arguments.py
+++ b/client/command_arguments.py
@@ -275,6 +275,7 @@ class AnalyzeArguments:
     maximum_trace_length: Optional[int] = None
     no_verify: bool = False
     verify_dsl: bool = False
+    verify_taint_config_only: bool = False
     output: str = TEXT
     repository_root: Optional[str] = None
     rule: List[int] = field(default_factory=list)

--- a/client/commands/analyze.py
+++ b/client/commands/analyze.py
@@ -56,6 +56,7 @@ class Arguments:
     maximum_trace_length: Optional[int] = None
     no_verify: bool = False
     verify_dsl: bool = False
+    verify_taint_config_only: bool = False
     repository_root: Optional[str] = None
     rule_filter: Optional[Sequence[int]] = None
     source_filter: Optional[Sequence[str]] = None
@@ -172,6 +173,7 @@ class Arguments:
             ),
             "no_verify": self.no_verify,
             "verify_dsl": self.verify_dsl,
+            "verify_taint_config_only": self.verify_taint_config_only,
             **({} if repository_root is None else {"repository_root": repository_root}),
             **({} if rule_filter is None else {"rule_filter": rule_filter}),
             **({} if source_filter is None else {"source_filter": source_filter}),
@@ -278,6 +280,7 @@ def create_analyze_arguments(
         maximum_trace_length=analyze_arguments.maximum_trace_length,
         no_verify=analyze_arguments.no_verify,
         verify_dsl=analyze_arguments.verify_dsl,
+        verify_taint_config_only=analyze_arguments.verify_taint_config_only,
         repository_root=repository_root,
         rule_filter=None if len(rule) == 0 else rule,
         source_filter=None if len(source) == 0 else source,

--- a/client/pyre.py
+++ b/client/pyre.py
@@ -400,6 +400,12 @@ def pyre(
     help="Verify DSL model queries for the taint analysis.",
 )
 @click.option(
+    "--verify-taint-config-only",
+    is_flag=True,
+    default=False,
+    help="Verify taint.config files. Skips analysis.",
+)
+@click.option(
     "--version",
     is_flag=True,
     default=False,
@@ -541,6 +547,7 @@ def analyze(
     taint_models_path: Iterable[str],
     no_verify: bool,
     verify_dsl: bool,
+    verify_taint_config_only: bool,
     version: bool,
     save_results_to: Optional[str],
     output_format: Optional[str],
@@ -604,6 +611,7 @@ def analyze(
             maximum_trace_length=maximum_trace_length,
             no_verify=no_verify,
             verify_dsl=verify_dsl,
+            verify_taint_config_only=verify_taint_config_only,
             output=command_argument.output,
             repository_root=repository_root,
             rule=list(rule),

--- a/source/command/analyzeCommand.mli
+++ b/source/command/analyzeCommand.mli
@@ -36,6 +36,7 @@ module AnalyzeConfiguration : sig
     maximum_tito_depth: int option;
     no_verify: bool;
     verify_dsl: bool;
+    verify_taint_config_only: bool;
     repository_root: PyrePath.t option;
     rule_filter: int list option;
     source_filter: string list option;

--- a/source/command/test/analyzeTest.ml
+++ b/source/command/test/analyzeTest.ml
@@ -54,6 +54,7 @@ let test_json_parsing context =
       use_cache = false;
       no_verify = false;
       verify_dsl = false;
+      verify_taint_config_only = false;
       check_invariants = false;
       limit_entrypoints = false;
     }

--- a/source/configuration.ml
+++ b/source/configuration.ml
@@ -520,6 +520,7 @@ module StaticAnalysis = struct
     dump_call_graph: PyrePath.t option;
     verify_models: bool;
     verify_dsl: bool;
+    verify_taint_config_only: bool;
     (* Analysis configuration *)
     configuration: Analysis.t;
     rule_filter: int list option;
@@ -553,6 +554,7 @@ module StaticAnalysis = struct
       ?dump_call_graph
       ?(verify_models = true)
       ?(verify_dsl = true)
+      ?(verify_taint_config_only = false)
       ?rule_filter
       ?source_filter
       ?sink_filter
@@ -583,6 +585,7 @@ module StaticAnalysis = struct
       dump_call_graph;
       verify_models;
       verify_dsl;
+      verify_taint_config_only;
       configuration;
       rule_filter;
       source_filter;

--- a/source/configuration.mli
+++ b/source/configuration.mli
@@ -232,6 +232,7 @@ module StaticAnalysis : sig
     dump_call_graph: PyrePath.t option;
     verify_models: bool;
     verify_dsl: bool;
+    verify_taint_config_only: bool;
     (* Analysis configuration *)
     configuration: Analysis.t;
     rule_filter: int list option;
@@ -265,6 +266,7 @@ module StaticAnalysis : sig
     ?dump_call_graph:PyrePath.t ->
     ?verify_models:bool ->
     ?verify_dsl:bool ->
+    ?verify_taint_config_only:bool ->
     ?rule_filter:int list ->
     ?source_filter:string list ->
     ?sink_filter:string list ->

--- a/source/interprocedural_analyses/taint/taintAnalysis.ml
+++ b/source/interprocedural_analyses/taint/taintAnalysis.ml
@@ -36,10 +36,10 @@ let initialize_configuration
         _;
       }
   =
-  Log.info "Verifying model syntax and configuration.";
+  Log.info "Verifying taint configuration.";
   let timer = Timer.start () in
+  let open Core.Result in
   let taint_configuration =
-    let open Core.Result in
     TaintConfiguration.from_taint_model_paths taint_model_paths
     >>= TaintConfiguration.with_command_line_options
           ~rule_filter
@@ -61,19 +61,33 @@ let initialize_configuration
           ~maximum_tito_depth
     |> TaintConfiguration.exception_on_error
   in
-  (* In order to save time, sanity check models before starting the analysis. *)
-  let () =
-    ModelParser.get_model_sources ~paths:taint_model_paths
-    |> List.iter ~f:(fun (path, source) -> ModelParser.verify_model_syntax ~path ~source)
-  in
   let () =
     Statistics.performance
-      ~name:"Verified model syntax and configuration"
-      ~phase_name:"Verifying model syntax and configuration"
+      ~name:"Verified taint configuration"
+      ~phase_name:"Verifying taint configuration"
       ~timer
       ()
   in
   taint_configuration
+
+
+let verify_model_syntax ~static_analysis_configuration =
+  Log.info "Verifying model syntax.";
+  let timer = Timer.start () in
+  let () =
+    ModelParser.get_model_sources
+      ~paths:
+        static_analysis_configuration.Configuration.StaticAnalysis.configuration.taint_model_paths
+    |> List.iter ~f:(fun (path, source) -> ModelParser.verify_model_syntax ~path ~source)
+  in
+  let () =
+    Statistics.performance
+      ~name:"Verified model syntax"
+      ~phase_name:"Verifying model syntax"
+      ~timer
+      ()
+  in
+  ()
 
 
 let parse_decorator_preprocessing_configuration
@@ -342,6 +356,9 @@ let run_taint_analysis
     ()
   =
   let taint_configuration = initialize_configuration ~static_analysis_configuration in
+
+  (* In order to save time, sanity check models before starting the analysis. *)
+  let () = verify_model_syntax ~static_analysis_configuration in
 
   (* Parse taint models to find decorators to inline or discard. This must be done early because
      inlining is a preprocessing phase of type-checking. *)

--- a/source/interprocedural_analyses/taint/taintAnalysis.mli
+++ b/source/interprocedural_analyses/taint/taintAnalysis.mli
@@ -11,3 +11,7 @@ val run_taint_analysis
   scheduler:Scheduler.t ->
   unit ->
   unit
+
+val initialize_configuration
+  :  static_analysis_configuration:Configuration.StaticAnalysis.t ->
+  Taint.TaintConfiguration.Heap.t


### PR DESCRIPTION
Adds verify_taint_config_only option to the analyze command that just verifies taint.config files and skips the analysis. This can be useful in the future when we want to verify taint config files via the vs code extension without performing analysis or even any other sort of preprocessing.

Modifies the ocaml server and the python client to pass options for the same.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

## Test Plan
- Ran pysa with the default `taint.config` on `documentation/pysa_tutorial/exercise1/`:
<img width="955" alt="Screenshot 2023-05-31 at 3 48 17 PM" src="https://github.com/facebook/pyre-check/assets/8947010/66b9d095-77c5-4be3-872d-f98225609de8">

- Command: `python3 -m pyre-check.client.pyre -n analyze --verify-taint-config-only`

<img width="955" alt="Screenshot 2023-05-31 at 3 41 33 PM" src="https://github.com/facebook/pyre-check/assets/8947010/60244953-79e5-4c62-9089-266be884954e">

- Modify `taint.config` to induce a TaintConfigurationError:
```json
{
  "sources": [
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    }
  ],

  "sinks": [
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    }
  ],

  "features": [],

  "rules": [
    {
      "name": "Possible RCE:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    },
    {
      "name": "test-duplicate",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "duplicate"
    }
  ]
}
```
Command: `python3 -m pyre-check.client.pyre -n analyze --verify-taint-config-only`

<img width="955" alt="Screenshot 2023-05-31 at 3 42 49 PM" src="https://github.com/facebook/pyre-check/assets/8947010/150de5da-f5f0-415d-9407-808a6feb98bd">

- Github actions. (pysa action was failing before this PR)

Fixes part of https://github.com/MLH-Fellowship/pyre-check/issues/82
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
