### PR TITLE
Display positions in SourceDuplicate errors

### DIFF
--- a/source/interprocedural_analyses/taint/annotationParser.ml
+++ b/source/interprocedural_analyses/taint/annotationParser.ml
@@ -19,6 +19,7 @@ type taint_kind =
 type source_or_sink = {
   name: string;
   kind: taint_kind;
+  location: JsonParsing.JsonAst.LocationWithPath.t option;
 }
 
 let parse_source ~allowed ?subkind name =

--- a/source/interprocedural_analyses/taint/annotationParser.mli
+++ b/source/interprocedural_analyses/taint/annotationParser.mli
@@ -12,6 +12,7 @@ type taint_kind =
 type source_or_sink = {
   name: string;
   kind: taint_kind;
+  location: JsonParsing.JsonAst.LocationWithPath.t option;
 }
 
 val parse_source

--- a/source/interprocedural_analyses/taint/taintConfiguration.ml
+++ b/source/interprocedural_analyses/taint/taintConfiguration.ml
@@ -489,12 +489,12 @@ module Heap = struct
   let default =
     let sources =
       List.map
-        ~f:(fun name -> { AnnotationParser.name; kind = Named })
+        ~f:(fun name -> { AnnotationParser.name; kind = Named; location = None })
         ["Demo"; "Test"; "UserControlled"; "PII"; "Secrets"; "Cookies"]
     in
     let sinks =
       List.map
-        ~f:(fun name -> { AnnotationParser.name; kind = Named })
+        ~f:(fun name -> { AnnotationParser.name; kind = Named; location = None })
         [
           "Demo";
           "FileSystem";
@@ -733,7 +733,10 @@ module Error = struct
         previous_location: JsonAst.LocationWithPath.t option;
       }
     | OptionDuplicate of string
-    | SourceDuplicate of string
+    | SourceDuplicate of {
+        name: string;
+        previous_location: JsonAst.LocationWithPath.t option;
+      }
     | SinkDuplicate of string
     | TransformDuplicate of string
     | FeatureDuplicate of string
@@ -807,7 +810,17 @@ module Error = struct
           previous_location.location
     | OptionDuplicate name ->
         Format.fprintf formatter "Multiple values were passed in for option `%s`" name
-    | SourceDuplicate name -> Format.fprintf formatter "Duplicate entry for source: `%s`" name
+    | SourceDuplicate { name; previous_location = None } ->
+        Format.fprintf formatter "Duplicate entry for source: `%s`" name
+    | SourceDuplicate { name; previous_location = Some previous_location } ->
+        Format.fprintf
+          formatter
+          "Duplicate entry for source: `%s`, previous entry was at `%a:%a`"
+          name
+          PyrePath.pp
+          previous_location.path
+          JsonAst.Location.pp_start
+          previous_location.location
     | SinkDuplicate name -> Format.fprintf formatter "Duplicate entry for sink: `%s`" name
     | TransformDuplicate name -> Format.fprintf formatter "Duplicate entry for transform: `%s`" name
     | FeatureDuplicate name -> Format.fprintf formatter "Duplicate entry for feature: `%s`" name
@@ -899,6 +912,13 @@ let from_json_list source_json_list =
     json_exception_to_error ~path ~section:key (fun () ->
         JsonAst.Json.Util.member_exn key value |> JsonAst.Json.Util.to_string_exn |> Result.return)
   in
+  let json_string_member_with_location ~path key value =
+    json_exception_to_error ~path ~section:key (fun () ->
+        let node = JsonAst.Json.Util.member_exn key value in
+        let value = JsonAst.Json.Util.to_string_exn node in
+        let location = JsonAst.Json.Util.to_location_exn node in
+        Result.return (value, location))
+  in
   let json_integer_member_with_location ~path key value =
     json_exception_to_error ~path ~section:key (fun () ->
         let node = JsonAst.Json.Util.member_exn key value in
@@ -961,8 +981,15 @@ let from_json_list source_json_list =
       ~current_keys:(JsonAst.Json.Util.keys json)
       ~valid_keys:["name"; "kind"; "comment"]
     >>= fun () ->
-    json_string_member ~path "name" json
-    >>= fun name -> parse_kind ~path json >>| fun kind -> { AnnotationParser.name; kind }
+    json_string_member_with_location ~path "name" json
+    >>= fun (name, location) ->
+    parse_kind ~path json
+    >>| fun kind ->
+    {
+      AnnotationParser.name;
+      kind;
+      location = Some (JsonAst.LocationWithPath.create ~path ~location);
+    }
   in
   let parse_source_annotations (path, json) =
     array_member ~path "sources" json
@@ -1573,9 +1600,11 @@ let validate ({ Heap.sources; sinks; transforms; features; rules; _ } as configu
   in
   Result.combine_errors_unit
     [
-      ensure_list_unique
-        ~get_name:(fun { AnnotationParser.name; _ } -> name)
-        ~get_error:(fun name -> Error.SourceDuplicate name)
+      ensure_list_unique_with_location
+        ~get_key:(fun { AnnotationParser.name; _ } -> name)
+        ~get_location:(fun { AnnotationParser.location; _ } -> location)
+        ~get_error:(fun { AnnotationParser.name; _ } previous_location ->
+          Error.SourceDuplicate { name; previous_location })
         sources;
       ensure_list_unique
         ~get_name:(fun { AnnotationParser.name; _ } -> name)

--- a/source/interprocedural_analyses/taint/taintConfiguration.mli
+++ b/source/interprocedural_analyses/taint/taintConfiguration.mli
@@ -149,7 +149,10 @@ module Error : sig
         previous_location: JsonParsing.JsonAst.LocationWithPath.t option;
       }
     | OptionDuplicate of string
-    | SourceDuplicate of string
+    | SourceDuplicate of {
+        name: string;
+        previous_location: JsonParsing.JsonAst.LocationWithPath.t option;
+      }
     | SinkDuplicate of string
     | TransformDuplicate of string
     | FeatureDuplicate of string

--- a/source/interprocedural_analyses/taint/test/annotationParserTest.ml
+++ b/source/interprocedural_analyses/taint/test/annotationParserTest.ml
@@ -9,9 +9,9 @@ open OUnit2
 open Core
 open Taint
 
-let named name = { AnnotationParser.name; kind = Named }
+let named name = { AnnotationParser.name; kind = Named; location = None }
 
-let parametric name = { AnnotationParser.name; kind = Parametric }
+let parametric name = { AnnotationParser.name; kind = Parametric; location = None }
 
 let test_parse_source _ =
   let assert_parsed ~allowed ?subkind ~expected source =

--- a/source/interprocedural_analyses/taint/test/modelTest.ml
+++ b/source/interprocedural_analyses/taint/test/modelTest.ml
@@ -30,14 +30,14 @@ let set_up_environment
   in
   let project = ScratchProject.setup ~context ["test.py", source] in
   let taint_configuration =
-    let named name = { AnnotationParser.name; kind = Named } in
+    let named name = { AnnotationParser.name; kind = Named; location = None } in
     let sources =
       [
         named "TestTest";
         named "UserControlled";
         named "Test";
         named "Demo";
-        { AnnotationParser.name = "WithSubkind"; kind = Parametric };
+        { AnnotationParser.name = "WithSubkind"; kind = Parametric; location = None };
       ]
     in
     let sinks =
@@ -47,7 +47,7 @@ let set_up_environment
         named "Test";
         named "Demo";
         named "XSS";
-        { AnnotationParser.name = "TestSinkWithSubkind"; kind = Parametric };
+        { AnnotationParser.name = "TestSinkWithSubkind"; kind = Parametric; location = None };
       ]
     in
     let transforms = [TaintTransform.Named "TestTransform"; TaintTransform.Named "DemoTransform"] in
@@ -183,8 +183,13 @@ let assert_invalid_model ?path ?source ?(sources = []) ~context ~model_source ~e
       {
         empty with
         sources =
-          List.map ~f:(fun name -> { AnnotationParser.name; kind = Named }) ["A"; "B"; "Test"];
-        sinks = List.map ~f:(fun name -> { AnnotationParser.name; kind = Named }) ["X"; "Y"; "Test"];
+          List.map
+            ~f:(fun name -> { AnnotationParser.name; kind = Named; location = None })
+            ["A"; "B"; "Test"];
+        sinks =
+          List.map
+            ~f:(fun name -> { AnnotationParser.name; kind = Named; location = None })
+            ["X"; "Y"; "Test"];
         features = ["featureA"; "featureB"];
         rules = [];
         partial_sink_labels =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Previously when SourceDuplicate errors occured, we just left a note specifying the duplicate name. Now we can specify the locations where the duplicates occured.

Modifies annotationParser as annotationParser.source_or_sink is where the sink or source is parsed into from taint.config files to contain the location information to be used incase duplicates occur.

Modifies and updates tests to confirm and check the new record field and type of SourceDuplicate error.

## Test Plan

- Post changes with the default `taint.config`, running pysa on `documentation/pysa_tutorial/exercise1`

<img width="941" alt="Screenshot 2023-06-02 at 1 21 52 PM" src="https://github.com/facebook/pyre-check/assets/8947010/2dcdae0e-672c-4b95-a888-e73a829a7493">

- Modify `taint.config` to:
```
{
  "sources": [
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    },
    {
      "name": "CustomUserControlled",
      "comment": "duplicate for testing"
    }
  ],

  "sinks": [
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    }
  ],

  "features": [],

  "rules": [
    {
      "name": "Possible RCE:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    }
  ]
}
```

Before this PR:
<img width="941" alt="Screenshot 2023-06-02 at 1 27 04 PM" src="https://github.com/facebook/pyre-check/assets/8947010/7ad937d4-e4b3-4acf-8fc3-e0646aa39a7d">


After this PR:
<img width="941" alt="Screenshot 2023-06-02 at 1 25 08 PM" src="https://github.com/facebook/pyre-check/assets/8947010/5ef8927d-fa95-44c2-bb82-3ac3532b731f">

- `make test`

Footnotes:
- pysa github action was failing before this PR

Fixes part of: https://github.com/MLH-Fellowship/pyre-check/issues/82
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>