### PR TITLE
Adds InvalidRegex TaintConfiguration Error type

### DIFF
--- a/source/interprocedural_analyses/taint/taintConfiguration.mli
+++ b/source/interprocedural_analyses/taint/taintConfiguration.mli
@@ -156,6 +156,10 @@ module Error : sig
     | SinkDuplicate of string
     | TransformDuplicate of string
     | FeatureDuplicate of string
+    | InvalidRegex of {
+        regex: string;
+        reason: string;
+      }
   [@@deriving equal, show]
 
   type t = {


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Adds new error type that can handle Re2 compilation failed exceptions. Previously, when a regex compilation failed, the exception wasn't caught and the program terminated abnormally.

Catch the exception, and throw a custom TaintConfiguration Error to expose the underlying reason why the compilation failed and exit in a more user-friendly fashion.

## Test Plan

- taint.config used:
```json
{
  "sources": [
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    }
  ],
  "implicit_sources": {
     "literal_strings": [
       {
         "regexp": "\\d{1Z,3}(\\.\\d{1,3}+",
         "kind": "CustomUserControlled",
         "description": "String that looks like an IP address."
       }
     ]
  },
  "sinks": [
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    }
  ],

  "features": [],

  "rules": [
    {
      "name": "Possible RCE:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    }
  ]
}
```

Before:
<img width="990" alt="before" src="https://github.com/facebook/pyre-check/assets/8947010/2d98a7e3-7650-439b-84e5-e300f758bb47">

After:
<img width="990" alt="after" src="https://github.com/facebook/pyre-check/assets/8947010/5aa82960-eae0-4681-b7e8-949079448042">

Fixes part of: https://github.com/MLH-Fellowship/pyre-check/issues/82
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

- `make test`