### PR TITLE
Declare the encoding of README.md as UTF-8 in /scripts/pypi/setup.py

### DIFF
--- a/scripts/pypi/setup.py
+++ b/scripts/pypi/setup.py
@@ -148,7 +148,7 @@ def run(
 
 
 def main() -> None:
-    with open("README.md") as f:
+    with open("README.md", encoding="utf-8") as f:
         long_description = f.read()
 
     run(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary
Detail at #746 
## Test Plan
Before this PR:
```
pip install pyre-check -v
Using pip 23.1.2 from D:\Program Files\Python39\lib\site-packages\pip (python 3.9)
Collecting pyre-check
  Using cached pyre-check-0.9.18.tar.gz (18.0 MB)
  Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "C:\Users\C\AppData\Local\Temp\pip-install-vl66c10k\pyre-check_777ff74193d447fbb3aff7d9daa5b154\setup.py", line 164, in <module>
      main()
    File "C:\Users\C\AppData\Local\Temp\pip-install-vl66c10k\pyre-check_777ff74193d447fbb3aff7d9daa5b154\setup.py", line 152, in main
      long_description = f.read()
  UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 992: illegal multibyte sequence
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: 'D:\Program Files\Python39\python.exe' -c '
  exec(compile('"'"''"'"''"'"'
  # This is <pip-setuptools-caller> -- a caller that pip uses to run setup.py
  #
  # - It imports setuptools before invoking setup.py, to enable projects that directly
  #   import from `distutils.core` to work with newer packaging standards.
  # - It provides a clear error message when setuptools is not installed.
  # - It sets `sys.argv[0]` to the underlying `setup.py`, when invoking `setup.py` so
  #   setuptools doesn'"'"'t think the script is `-c`. This avoids the following warning:
  #     manifest_maker: standard file '"'"'-c'"'"' not found".
  # - It generates a shim setup.py, for handling setup.cfg-only projects.
  import os, sys, tokenize

  try:
      import setuptools
  except ImportError as error:
      print(
          "ERROR: Can not execute `setup.py` since setuptools is not available in "
          "the build environment.",
          file=sys.stderr,
      )
      sys.exit(1)

  __file__ = %r
  sys.argv[0] = __file__

  if os.path.exists(__file__):
      filename = __file__
      with tokenize.open(__file__) as f:
          setup_py_code = f.read()
  else:
      filename = "<auto-generated setuptools caller>"
      setup_py_code = "from setuptools import setup; setup()"

  exec(compile(setup_py_code, filename, "exec"))
  '"'"''"'"''"'"' % ('"'"'C:\\Users\\C\\AppData\\Local\\Temp\\pip-install-vl66c10k\\pyre-check_777ff74193d447fbb3aff7d9daa5b154\\setup.py'"'"',), "<pip-setuptools-caller>", "exec"))' egg_info --egg-base 'C:\Users\C\AppData\Local\Temp\pip-pip-egg-info-k_ri_km9'
  cwd: C:\Users\C\AppData\Local\Temp\pip-install-vl66c10k\pyre-check_777ff74193d447fbb3aff7d9daa5b154\
  Preparing metadata (setup.py) ... error
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
After this PR:
```
D:\Download\pyre-check-0.9.18 > pip install .
Processing d:\download\pyre-check-0.9.18
  Preparing metadata (setup.py) ... done
Requirement already satisfied: click>=8.0 in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (8.1.3)
Requirement already satisfied: dataclasses-json in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (0.5.8)
Requirement already satisfied: intervaltree in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (3.1.0)
Requirement already satisfied: libcst in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (1.0.1)
Requirement already satisfied: psutil in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (5.9.5)
Requirement already satisfied: pyre-extensions>=0.0.29 in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (0.0.30)
Requirement already satisfied: tabulate in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (0.9.0)
Requirement already satisfied: testslide>=2.7.0 in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (2.7.1)
Requirement already satisfied: typing_extensions in d:\program files\python39\lib\site-packages (from pyre-check==0.9.18) (4.5.0)
Requirement already satisfied: colorama in d:\program files\python39\lib\site-packages (from click>=8.0->pyre-check==0.9.18) (0.4.6)
Requirement already satisfied: typing-inspect in d:\program files\python39\lib\site-packages (from pyre-extensions>=0.0.29->pyre-check==0.9.18) (0.9.0)
Requirement already satisfied: Pygments>=2.2.0 in d:\program files\python39\lib\site-packages (from testslide>=2.7.0->pyre-check==0.9.18) (2.14.0)
Requirement already satisfied: typeguard<3.0 in d:\program files\python39\lib\site-packages (from testslide>=2.7.0->pyre-check==0.9.18) (2.13.3)
Requirement already satisfied: marshmallow<4.0.0,>=3.3.0 in d:\program files\python39\lib\site-packages (from dataclasses-json->pyre-check==0.9.18) (3.19.0)
Requirement already satisfied: marshmallow-enum<2.0.0,>=1.5.1 in d:\program files\python39\lib\site-packages (from dataclasses-json->pyre-check==0.9.18) (1.5.1)
Requirement already satisfied: sortedcontainers<3.0,>=2.0 in d:\program files\python39\lib\site-packages (from intervaltree->pyre-check==0.9.18) (2.4.0)
Requirement already satisfied: pyyaml>=5.2 in d:\program files\python39\lib\site-packages (from libcst->pyre-check==0.9.18) (6.0)
Requirement already satisfied: packaging>=17.0 in d:\program files\python39\lib\site-packages (from marshmallow<4.0.0,>=3.3.0->dataclasses-json->pyre-check==0.9.18) (23.0)
Requirement already satisfied: mypy-extensions>=0.3.0 in d:\program files\python39\lib\site-packages (from typing-inspect->pyre-extensions>=0.0.29->pyre-check==0.9.18) (1.0.0)
Building wheels for collected packages: pyre-check
  Building wheel for pyre-check (setup.py) ... done
  Created wheel for pyre-check: filename=pyre_check-0.9.18-py3-none-any.whl size=19378449 sha256=3f5c5fe71a046370e14533f7054457d34be969d0b7523c9d66a89d6858d7d256
  Stored in directory: c:\users\c\appdata\local\pip\cache\wheels\ed\6c\8a\2c2e2c4534ebd3443092b785b0eb52c4138ba8b459b1dd09d7
Successfully built pyre-check
Installing collected packages: pyre-check
Successfully installed pyre-check-0.9.18
```