### PR TITLE
Set the opam CLI version as 2.1 manually when build Pyre(and Pysa)

### DIFF
--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -33,6 +33,7 @@ jobs:
           echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/4.14.0/lib/stublibs:$HOME/.opam/4.14.0/lib/ocaml/stublibs:$HOME/.opam/4.14.0/lib/ocam" >> $GITHUB_ENV
           echo "$HOME/.opam/4.14.0/bin" >> $GITHUB_PATH
           echo "/home/opam/.opam/4.14.0/bin" >> $GITHUB_PATH
+          echo "OPAMCLI=2.1" >> $GITHUB_ENV
 
       - name: Build Pyre (and Pysa)
         run: |

--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -33,7 +33,6 @@ jobs:
           echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/4.14.0/lib/stublibs:$HOME/.opam/4.14.0/lib/ocaml/stublibs:$HOME/.opam/4.14.0/lib/ocam" >> $GITHUB_ENV
           echo "$HOME/.opam/4.14.0/bin" >> $GITHUB_PATH
           echo "/home/opam/.opam/4.14.0/bin" >> $GITHUB_PATH
-          echo "OPAMCLI=2.1" >> $GITHUB_ENV
 
       - name: Build Pyre (and Pysa)
         run: |

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -209,7 +209,7 @@ class Setup(NamedTuple):
         )
         opam_environment_variables = self.opam_environment_variables()
 
-        opam_install_command = ["opam", "install", "--yes"]
+        opam_install_command = ["opam", "install", "--yes", "--cli=2.1"]
 
         if sys.platform == "linux":
             # setting `--assume-depexts` means that opam will not require a "system"
@@ -233,6 +233,7 @@ class Setup(NamedTuple):
                 self.switch_name(),
                 "--root",
                 self.opam_root.as_posix(),
+                "--cli=2.1",
             ]
         )
 
@@ -240,7 +241,7 @@ class Setup(NamedTuple):
         if rust_path is not None:
             environment_variables["PATH"] = str(rust_path) + ":" + environment_variables["PATH"]
 
-        opam_install_command = ["opam", "install", "--yes"]
+        opam_install_command = ["opam", "install", "--yes", "--cli=2.1"]
 
         if sys.platform == "linux":
             # osx fails on sandcastle with exit status 2 (illegal argument) with this.

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -163,6 +163,7 @@ class Setup(NamedTuple):
                 self.opam_root.as_posix(),
                 "--set-root",
                 "--set-switch",
+                "--cli=2.1",
             ]
         )
         opam_environment_variables: Dict[str, str] = {}
@@ -185,6 +186,7 @@ class Setup(NamedTuple):
             [
                 "opam",
                 "init",
+                "--cli=2.1",
                 "--bare",
                 "--yes",
                 "--disable-sandboxing",
@@ -194,7 +196,7 @@ class Setup(NamedTuple):
                 "https://opam.ocaml.org",
             ]
         )
-        self.run(["opam", "update", "--root", self.opam_root.as_posix()])
+        self.run(["opam", "update", "--root", self.opam_root.as_posix(), "--cli=2.1"])
         self.run(
             [
                 "opam",

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -205,6 +205,7 @@ class Setup(NamedTuple):
                 "--yes",
                 "--root",
                 self.opam_root.as_posix(),
+                "--cli=2.1",
             ]
         )
         opam_environment_variables = self.opam_environment_variables()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Detail at GH-752
## Test Plan
Before this PR:
![image](https://github.com/facebook/pyre-check/assets/120731947/b68040eb-b3f3-474f-8604-262631c06b5d)
After this PR:
![image](https://github.com/facebook/pyre-check/assets/120731947/9e4e6c53-6351-4634-9dac-b4e41eec66df)
