### PR TITLE
Fix the condition in /client/pyre.py, function run_default_command

### DIFF
--- a/client/pyre.py
+++ b/client/pyre.py
@@ -1554,7 +1554,7 @@ def run_default_command(
     **kwargs: object,
 ) -> commands.ExitCode:
     command_argument: command_arguments.CommandArguments = context.obj["arguments"]
-    if command_argument.version:
+    if command_argument.version != command_arguments.VersionKind.NONE:
         _show_pyre_version(command_argument)
         return commands.ExitCode.SUCCESS
     elif context.invoked_subcommand is None:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
After 6de35ff7004b9e69cbf66a58156a654782791ced, we use
`command_arguments.VersionKind.NONE` instead of real `None` in Python when we need to do something about version.
But, at file /client/pyre.py, function `run_default_command`, line 1550, we still use `if command_argument.version:`.
Obviously, this condition will always evaluate as `True`, because its default value is `command_arguments.VersionKind.NONE`,
equals `"none"`
So, we just change it to:
```python
if command_argument.version != command_arguments.VersionKind.NONE:
    ...
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
