### PR TITLE
Display positions in SinkDuplicate errors

### DIFF
--- a/source/interprocedural_analyses/taint/taintConfiguration.mli
+++ b/source/interprocedural_analyses/taint/taintConfiguration.mli
@@ -153,7 +153,10 @@ module Error : sig
         name: string;
         previous_location: JsonParsing.JsonAst.LocationWithPath.t option;
       }
-    | SinkDuplicate of string
+    | SinkDuplicate of {
+        name: string;
+        previous_location: JsonParsing.JsonAst.LocationWithPath.t option;
+      }
     | TransformDuplicate of string
     | FeatureDuplicate of string
   [@@deriving equal, show]

--- a/source/interprocedural_analyses/taint/test/configurationTest.ml
+++ b/source/interprocedural_analyses/taint/test/configurationTest.ml
@@ -809,7 +809,24 @@ let test_validate _ =
     }
     |};
   assert_parse_error
-    ~errors:[TaintConfiguration.Error.SinkDuplicate "Test"]
+    ~errors:
+      [
+        TaintConfiguration.Error.SinkDuplicate
+          {
+            name = "Test";
+            previous_location =
+              Some
+                {
+                  JsonParsing.JsonAst.LocationWithPath.path =
+                    PyrePath.create_absolute "/taint.config";
+                  location =
+                    {
+                      JsonParsing.JsonAst.Location.start = { line = 6; column = 18 };
+                      stop = { line = 6; column = 23 };
+                    };
+                };
+          };
+      ]
     {|
     {
       "sources": [
@@ -868,7 +885,21 @@ let test_validate _ =
                     };
                 };
           };
-        TaintConfiguration.Error.SinkDuplicate "Test";
+        TaintConfiguration.Error.SinkDuplicate
+          {
+            name = "Test";
+            previous_location =
+              Some
+                {
+                  JsonParsing.JsonAst.LocationWithPath.path =
+                    PyrePath.create_absolute "/taint.config";
+                  location =
+                    {
+                      JsonParsing.JsonAst.Location.start = { line = 8; column = 18 };
+                      stop = { line = 8; column = 23 };
+                    };
+                };
+          };
         TaintConfiguration.Error.FeatureDuplicate "concat";
       ]
     {|
@@ -921,7 +952,24 @@ let test_validate _ =
     }
     |};
   assert_parse_error
-    ~errors:[TaintConfiguration.Error.SinkDuplicate "Test"]
+    ~errors:
+      [
+        TaintConfiguration.Error.SinkDuplicate
+          {
+            name = "Test";
+            previous_location =
+              Some
+                {
+                  JsonParsing.JsonAst.LocationWithPath.path =
+                    PyrePath.create_absolute "/taint.config";
+                  location =
+                    {
+                      JsonParsing.JsonAst.Location.start = { line = 5; column = 18 };
+                      stop = { line = 5; column = 23 };
+                    };
+                };
+          };
+      ]
     {|
     {
       "sinks": [


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Previously when SinkDuplicate errors occured, we just displayed a note. Now we can display locations where the duplicates occured.

Modifies and updates test as well.

## Test Plan

- Post changes with the default `taint.config`, running pysa on `documentation/pysa_tutorial/exercise1`

<img width="878" alt="Screenshot 2023-07-20 at 11 46 33 AM" src="https://github.com/facebook/pyre-check/assets/8947010/7edafa01-19b1-4544-94e2-d5f1195c6e41">

- Modify `taint.config` to:

```json
{
  "sources": [
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    }
  ],

  "sinks": [
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    },
    {
      "name": "CodeExecution",
      "comment": "duplicate for testing"
    }
  ],

  "features": [],

  "rules": [
    {
      "name": "Possible RCE:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    }
  ]
}
```

Before this PR:

<img width="878" alt="Screenshot 2023-07-20 at 11 53 32 AM" src="https://github.com/facebook/pyre-check/assets/8947010/2d69be60-bb9d-4806-a3ae-9d5a83e48f8a">


After this PR:

<img width="878" alt="Screenshot 2023-07-20 at 11 47 49 AM" src="https://github.com/facebook/pyre-check/assets/8947010/c269de27-0351-425d-8912-8e9360884ca9">

- `make test`

Fixes part of: https://github.com/MLH-Fellowship/pyre-check/issues/82
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

