### PR TITLE
Fix bootstrap script for non (ba)sh script

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -173,6 +173,7 @@ class Setup(NamedTuple):
                 self.opam_root.as_posix(),
                 "--set-root",
                 "--set-switch",
+                "--shell=bash",
             ]
         )
         opam_environment_variables: Dict[str, str] = {}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->
Fixes https://github.com/facebook/pyre-check/issues/758

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Force `opam env` to give a `bash` like output.

This allows us to parse the environment variables correctly further down.

`opam env` also has the option to export the environment as s-exp but I decided to not use it this time as I would realistically add another dependency to the script.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

This allows me to run the bootstrap script from my fish session.
