### PR TITLE
Use if-elif-else instead match-case to support Python less than 3.10

### DIFF
--- a/client/language_server/code_navigation_request.py
+++ b/client/language_server/code_navigation_request.py
@@ -114,15 +114,14 @@ class PyreCompletionItemKind(str, enum.Enum):
     PROPERTY = "PROPERTY"
 
     def to_lsp_completion_item_kind(self) -> lsp.CompletionItemKind:
-        match self:
-            case self.SIMPLE:
-                return lsp.CompletionItemKind.TEXT
-            case self.METHOD:
-                return lsp.CompletionItemKind.METHOD
-            case self.PROPERTY:
-                return lsp.CompletionItemKind.PROPERTY
-            case _:
-                return lsp.CompletionItemKind.TEXT
+        if self == self.SIMPLE:
+            return lsp.CompletionItemKind.TEXT
+        elif self == self.METHOD:
+            return lsp.CompletionItemKind.METHOD
+        elif self == self.PROPERTY:
+            return lsp.CompletionItemKind.PROPERTY
+        else:
+            return lsp.CompletionItemKind.TEXT
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
In [commit `Fix pyre_language_server completion response parsing`, file client/language_server/code_navigation_request.py, L116-L125](https://github.com/facebook/pyre-check/commit/5db6e5d1f96645db17d4ad59a6708f56d6516c23#diff-2cbcdc81e14a25a53c1694f5cf24f4f0e4e2cc5bfb61b574f18585be88e4ece5R116-R125), we used match-case statement.
But, this statement was added in `Python 3.10`, and we are still supporting Python >= 3.8
So, we need to use if-elif-else statement instead.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
[The script](client/language_server/code_navigation_request.py) now can run in any version of Python that >= 3.8
<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->


* Footnote: Pyre Github Actions were failing before and is unrelated to this PR.(Actually this PR fixed the workflow `tests`)