### PR TITLE
Fix Pyre path find when init Pysa

### DIFF
--- a/client/commands/initialize_pysa.py
+++ b/client/commands/initialize_pysa.py
@@ -73,10 +73,10 @@ def _setup_environment() -> None:
     run_infer = log.get_yes_no_input("Would you like to generate type annotations?")
     if run_infer:
         subprocess.run(["pyre", "infer", "-i"], check=True)
-    pyre_check_path = find_pysa_filters_directory()
-    if pyre_check_path is not None:
+    pysa_filter_path = find_pysa_filters_directory()
+    if pysa_filter_path is not None:
         LOG.info("Importing filters to sapp")
-        subprocess.run(["sapp", "filter", "import", pyre_check_path], check=True)
+        subprocess.run(["sapp", "filter", "import", pysa_filter_path], check=True)
     else:
         LOG.warning("Couldn't infer filter directory, skipping filter import to sapp.")
 

--- a/client/commands/initialize_pysa.py
+++ b/client/commands/initialize_pysa.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from .. import log
-from ..find_directories import find_taint_models_directory
+from ..find_directories import find_pyre_path
 
 from . import commands
 from .initialize import (
@@ -73,9 +73,8 @@ def _setup_environment() -> None:
     run_infer = log.get_yes_no_input("Would you like to generate type annotations?")
     if run_infer:
         subprocess.run(["pyre", "infer", "-i"], check=True)
-    pyre_check_path = find_taint_models_directory()
-    if pyre_check_path and os.path.isdir(pyre_check_path / "pyre_check"):
-        pyre_check_path = pyre_check_path / "pyre_check"
+    pyre_check_path = find_pyre_path()
+    if pyre_check_path is not None:
         LOG.info("Importing filters to sapp")
         subprocess.run(["sapp", "filter", "import", pyre_check_path], check=True)
     else:

--- a/client/commands/initialize_pysa.py
+++ b/client/commands/initialize_pysa.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from .. import log
-from ..find_directories import find_pyre_path
+from ..find_directories import find_pyre_directory
 
 from . import commands
 from .initialize import (
@@ -73,7 +73,7 @@ def _setup_environment() -> None:
     run_infer = log.get_yes_no_input("Would you like to generate type annotations?")
     if run_infer:
         subprocess.run(["pyre", "infer", "-i"], check=True)
-    pyre_check_path = find_pyre_path()
+    pyre_check_path = find_pyre_directory()
     if pyre_check_path is not None:
         LOG.info("Importing filters to sapp")
         subprocess.run(["sapp", "filter", "import", pyre_check_path], check=True)

--- a/client/commands/initialize_pysa.py
+++ b/client/commands/initialize_pysa.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from .. import log
-from ..find_directories import find_pyre_directory
+from ..find_directories import find_pysa_filters_directory
 
 from . import commands
 from .initialize import (
@@ -73,7 +73,7 @@ def _setup_environment() -> None:
     run_infer = log.get_yes_no_input("Would you like to generate type annotations?")
     if run_infer:
         subprocess.run(["pyre", "infer", "-i"], check=True)
-    pyre_check_path = find_pyre_directory()
+    pyre_check_path = find_pysa_filters_directory()
     if pyre_check_path is not None:
         LOG.info("Importing filters to sapp")
         subprocess.run(["sapp", "filter", "import", pyre_check_path], check=True)

--- a/client/find_directories.py
+++ b/client/find_directories.py
@@ -301,7 +301,7 @@ def find_typeshed_search_paths(
     return search_path
 
 
-def find_pyre_path() -> Optional[Path]:
+def find_pyre_directory() -> Optional[Path]:
     install_root = Path(sys.prefix)
     excepted_pyre_path = install_root / "lib/pyre_check/"
     if excepted_pyre_path.is_dir():
@@ -310,7 +310,7 @@ def find_pyre_path() -> Optional[Path]:
 
 
 def find_taint_models_directory() -> Optional[Path]:
-    pyre_check_path = find_pyre_path()
+    pyre_check_path = find_pyre_directory()
     if pyre_check_path is not None:
         bundled_taint_models = pyre_check_path / "taint/"
         if bundled_taint_models.is_dir():

--- a/client/find_directories.py
+++ b/client/find_directories.py
@@ -311,13 +311,12 @@ def find_pyre_directory() -> Optional[Path]:
 
 def find_taint_models_directory() -> Optional[Path]:
     pyre_check_path = find_pyre_directory()
-    if pyre_check_path is not None:
-        bundled_taint_models = pyre_check_path / "taint/"
-        if bundled_taint_models.is_dir():
-            return bundled_taint_models
+    if pyre_check_path is None:
         return None
-    else:
-        return None
+    bundled_taint_models = pyre_check_path / "taint/"
+    if bundled_taint_models.is_dir():
+        return bundled_taint_models
+    return None
 
 
 def find_pysa_filters_directory() -> Optional[Path]:

--- a/client/find_directories.py
+++ b/client/find_directories.py
@@ -301,9 +301,20 @@ def find_typeshed_search_paths(
     return search_path
 
 
-def find_taint_models_directory() -> Optional[Path]:
+def find_pyre_path() -> Optional[Path]:
     install_root = Path(sys.prefix)
-    bundled_taint_models = install_root / "lib/pyre_check/taint/"
-    if bundled_taint_models.is_dir():
-        return bundled_taint_models
+    excepted_pyre_path = install_root / "lib/pyre_check/"
+    if excepted_pyre_path.is_dir():
+        return excepted_pyre_path
     return None
+
+
+def find_taint_models_directory() -> Optional[Path]:
+    pyre_check_path = find_pyre_path()
+    if pyre_check_path is not None:
+        bundled_taint_models = pyre_check_path / "taint/"
+        if bundled_taint_models.is_dir():
+            return bundled_taint_models
+        return None
+    else:
+        return None

--- a/client/find_directories.py
+++ b/client/find_directories.py
@@ -318,3 +318,13 @@ def find_taint_models_directory() -> Optional[Path]:
         return None
     else:
         return None
+
+
+def find_pysa_filters_directory() -> Optional[Path]:
+    pyre_check_path = find_pyre_directory()
+    if pyre_check_path is None:
+        return None
+    excepted_pysa_filter_path = pyre_check_path / "pysa_filters/"
+    if excepted_pysa_filter_path.is_dir():
+        return excepted_pysa_filter_path
+    return None


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
This PR fixed #710.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Pysa should init with no error message `Couldn't infer filter directory, skipping filter import to sapp.`
<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
