### PR TITLE
Display position in TransformDuplicate errors

### DIFF
--- a/source/interprocedural_analyses/taint/annotationParser.ml
+++ b/source/interprocedural_analyses/taint/annotationParser.ml
@@ -46,10 +46,15 @@ let parse_sink ~allowed ?subkind name =
   | _ -> Error (Format.sprintf "Unsupported taint sink `%s`" name)
 
 
-let parse_transform ~allowed name =
-  match List.find allowed ~f:(TaintTransform.equal (TaintTransform.Named name)) with
-  | Some transform -> Ok transform
-  | None -> Error (Format.sprintf "Unsupported transform `%s`" name)
+let parse_transform ~allowed reference_name =
+  match
+    List.find allowed ~f:(function
+        | TaintTransform.Named { name; _ } -> String.equal name reference_name
+        | _ -> false)
+  with
+  | Some (TaintTransform.Named { name; _ }) -> Ok (TaintTransform.Named { name; location = None })
+  | Some (TaintTransform.Sanitize _ as transform) -> Ok transform
+  | None -> Error (Format.sprintf "Unsupported transform `%s`" reference_name)
 
 
 let parse_tito ~allowed_transforms ?subkind name =

--- a/source/interprocedural_analyses/taint/taintConfiguration.mli
+++ b/source/interprocedural_analyses/taint/taintConfiguration.mli
@@ -157,7 +157,10 @@ module Error : sig
         name: string;
         previous_location: JsonParsing.JsonAst.LocationWithPath.t option;
       }
-    | TransformDuplicate of string
+    | TransformDuplicate of {
+        name: string;
+        previous_location: JsonParsing.JsonAst.LocationWithPath.t option;
+      }
     | FeatureDuplicate of string
     | InvalidRegex of {
         regex: string;

--- a/source/interprocedural_analyses/taint/taintTransform.ml
+++ b/source/interprocedural_analyses/taint/taintTransform.ml
@@ -13,14 +13,20 @@
 
 open Core
 
+type named_transform = {
+  name: string;
+  location: (JsonParsing.JsonAst.LocationWithPath.t option[@hash.ignore] [@sexp.opaque]);
+}
+[@@deriving compare, eq, hash, sexp]
+
 type t =
-  | Named of string
+  | Named of named_transform
   (* Invariant: set is not empty. *)
   | Sanitize of SanitizeTransformSet.t
 [@@deriving compare, eq, hash, sexp]
 
 let pp formatter = function
-  | Named transform -> Format.fprintf formatter "%s" transform
+  | Named { name; _ } -> Format.fprintf formatter "%s" name
   | Sanitize transforms -> SanitizeTransformSet.pp formatter transforms
 
 
@@ -39,3 +45,8 @@ let is_sanitize_transforms = function
 let get_sanitize_transforms = function
   | Named _ -> None
   | Sanitize sanitize -> Some sanitize
+
+
+let get_location = function
+  | Named { location; _ } -> location
+  | Sanitize _ -> None

--- a/source/interprocedural_analyses/taint/taintTransform.mli
+++ b/source/interprocedural_analyses/taint/taintTransform.mli
@@ -5,8 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+type named_transform = {
+  name: string;
+  location: (JsonParsing.JsonAst.LocationWithPath.t option[@hash.ignore] [@sexp.opaque]);
+}
+[@@deriving compare, eq, hash, sexp]
+
 type t =
-  | Named of string
+  | Named of named_transform
   (* Invariant: set is not empty. *)
   | Sanitize of SanitizeTransformSet.t
 [@@deriving compare, eq, hash, sexp]
@@ -20,3 +26,5 @@ val is_named_transform : t -> bool
 val is_sanitize_transforms : t -> bool
 
 val get_sanitize_transforms : t -> SanitizeTransformSet.t option
+
+val get_location : t -> JsonParsing.JsonAst.LocationWithPath.t option

--- a/source/interprocedural_analyses/taint/test/annotationParserTest.ml
+++ b/source/interprocedural_analyses/taint/test/annotationParserTest.ml
@@ -87,14 +87,15 @@ let test_parse_tito _ =
     in
     assert_equal ~cmp:String.equal expected error
   in
+  let named_transform name = TaintTransform.Named { name; location = None } in
   assert_parsed ~expected:Sinks.LocalReturn "LocalReturn";
   assert_parsed ~expected:(Sinks.ParameterUpdate 2) "ParameterUpdate2";
   assert_parsed
-    ~allowed_transforms:[TaintTransform.Named "T"]
+    ~allowed_transforms:[named_transform "T"]
     ~expected:
       (Sinks.Transform
          {
-           local = TaintTransforms.of_named_transforms [TaintTransform.Named "T"];
+           local = TaintTransforms.of_named_transforms [named_transform "T"];
            global = TaintTransforms.empty;
            base = Sinks.LocalReturn;
          })
@@ -105,12 +106,12 @@ let test_parse_tito _ =
     ~subkind:"Subkind"
     "foo";
   assert_parse_error
-    ~allowed_transforms:[TaintTransform.Named "T"]
+    ~allowed_transforms:[named_transform "T"]
     ~expected:"Unsupported transform `U`"
     ~subkind:"U"
     "Transform";
   assert_parse_error
-    ~allowed_transforms:[TaintTransform.Named "T"]
+    ~allowed_transforms:[named_transform "T"]
     ~expected:"Tito transform requires name of the transform as parameter"
     "Transform"
 

--- a/source/interprocedural_analyses/taint/test/forwardAnalysisTest.ml
+++ b/source/interprocedural_analyses/taint/test/forwardAnalysisTest.ml
@@ -1213,7 +1213,9 @@ let test_taint_in_taint_out_transform context =
           [
             Sources.Transform
               {
-                local = TaintTransforms.of_named_transforms [TaintTransform.Named "TestTransform"];
+                local =
+                  TaintTransforms.of_named_transforms
+                    [TaintTransform.Named { name = "TestTransform"; location = None }];
                 global = TaintTransforms.empty;
                 base = Sources.NamedSource "Test";
               };
@@ -1253,8 +1255,12 @@ let test_taint_in_taint_out_transform context =
           [
             Sources.Transform
               {
-                local = TaintTransforms.of_named_transforms [TaintTransform.Named "DemoTransform"];
-                global = TaintTransforms.of_named_transforms [TaintTransform.Named "TestTransform"];
+                local =
+                  TaintTransforms.of_named_transforms
+                    [TaintTransform.Named { name = "DemoTransform"; location = None }];
+                global =
+                  TaintTransforms.of_named_transforms
+                    [TaintTransform.Named { name = "TestTransform"; location = None }];
                 base = Sources.NamedSource "Test";
               };
           ]
@@ -1291,7 +1297,10 @@ let test_taint_in_taint_out_transform context =
               {
                 local =
                   TaintTransforms.of_named_transforms
-                    [TaintTransform.Named "DemoTransform"; TaintTransform.Named "TestTransform"];
+                    [
+                      TaintTransform.Named { name = "DemoTransform"; location = None };
+                      TaintTransform.Named { name = "TestTransform"; location = None };
+                    ];
                 global = TaintTransforms.empty;
                 base = Sources.NamedSource "Test";
               };

--- a/source/interprocedural_analyses/taint/test/modelTest.ml
+++ b/source/interprocedural_analyses/taint/test/modelTest.ml
@@ -50,7 +50,8 @@ let set_up_environment
         { AnnotationParser.name = "TestSinkWithSubkind"; kind = Parametric; location = None };
       ]
     in
-    let transforms = [TaintTransform.Named "TestTransform"; TaintTransform.Named "DemoTransform"] in
+    let named_transform name = TaintTransform.Named { name; location = None } in
+    let transforms = [named_transform "TestTransform"; named_transform "DemoTransform"] in
     let rules =
       match rules with
       | Some rules -> rules
@@ -2303,7 +2304,8 @@ let test_taint_in_taint_out_transform context =
                     Sinks.Transform
                       {
                         local =
-                          TaintTransforms.of_named_transforms [TaintTransform.Named "TestTransform"];
+                          TaintTransforms.of_named_transforms
+                            [TaintTransform.Named { name = "TestTransform"; location = None }];
                         global = TaintTransforms.empty;
                         base = Sinks.LocalReturn;
                       };
@@ -2319,7 +2321,8 @@ let test_taint_in_taint_out_transform context =
                     Sinks.Transform
                       {
                         local =
-                          TaintTransforms.of_named_transforms [TaintTransform.Named "TestTransform"];
+                          TaintTransforms.of_named_transforms
+                            [TaintTransform.Named { name = "TestTransform"; location = None }];
                         global = TaintTransforms.empty;
                         base = Sinks.ExtraTraceSink;
                       };


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Previously when TransformDuplicate errors occured, we just left a note specifying the duplicate name of the transform. Now we can specify the locations where the duplicates occur.

Modifies taintTransform to have a new type that holds location information (for parsed transforms, it is made None). The location information will only be present for transform node definitions in taint.config.

Modifies and updates tests to confirm and check the new type of TransformDuplicate error.

## Test Plan

- After the changes, ran on `documentation/pysa_tutorial/exercise1` with default `taint.config`:
<img width="990" alt="Screenshot 2023-08-10 at 7 18 12 PM" src="https://github.com/facebook/pyre-check/assets/8947010/4225782b-7346-4a30-adb2-ef1afda297eb">

- Changed `taint.config` to:

```json
{
  "sources": [
    {
      "name": "CustomUserControlled",
      "comment": "use to annotate user input"
    }
  ],

  "sinks": [
    {
      "name": "CodeExecution",
      "comment": "use to annotate execution of python code"
    }
  ],

  "transforms": [
    {
      "name": "Test",
      "comment": "Test transform"
    },
    {
      "name": "Test",
      "comment": "Test tranform duplicate"
    }
  ],

  "features": [],

  "rules": [
    {
      "name": "Possible RCE:",
      "code": 5001,
      "sources": [ "CustomUserControlled" ],
      "sinks": [ "CodeExecution" ],
      "message_format": "User specified data may reach a code execution sink"
    }
  ]
}
```

Before the changes
<img width="990" alt="before" src="https://github.com/facebook/pyre-check/assets/8947010/8ee07f7e-bf21-4aaf-9a72-ddce55bd8bc1">


After the changes

<img width="990" alt="after" src="https://github.com/facebook/pyre-check/assets/8947010/e256269b-d6ee-48c3-87cc-92b102e5c943">

- Ran tests with `make test`

Fixes part of https://github.com/MLH-Fellowship/pyre-check/issues/82
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>