### PR TITLE
Remove `-custom` mode from Dune

### DIFF
--- a/source/dune.in
+++ b/source/dune.in
@@ -395,8 +395,6 @@
    ppx_hash
    ppx_compare
    ppx_sexp_conv))
- (ocamlc_flags
-  (:standard -custom))
  (libraries core_unix.command_unix pyrelib))
 
 (alias


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

This is now deprecated and breaks the bytecode build if one opts in for it.

Specifically, removing this allows me to fix https://github.com/ocsigen/lwt/issues/999 when building in bytecode.
