### PR TITLE
Make pyre able to read configuration from `pyproject.toml`

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -45,6 +45,12 @@
       "site-package": "tabulate"
     },
     {
+      "site-package": "tomli"
+    },
+    {
+      "site-package": "tomli_w"
+    },
+    {
       "is_toplevel_module": true,
       "site-package": "typing_extensions"
     },

--- a/client/commands/initialize.py
+++ b/client/commands/initialize.py
@@ -266,12 +266,13 @@ def get_configuration_and_path(
 def write_configuration(
     configuration: Dict[str, Any], configuration_path: Path
 ) -> None:
-    with open(configuration_path, "wb+") as configuration_file:
-        if configuration_path.suffix.lower() == ".toml":
+    if configuration_path.suffix.lower() == ".toml":
+        with open(configuration_path, "wb+") as configuration_file:
             configuration = {"tool": {"pyre": configuration}}  # [tool.pyre] section
             tomli_w.dump(configuration, configuration_file)
-        else:
-            # assume to JSON
+    else:
+        # assume to JSON
+        with open(configuration_path, "w+") as configuration_file:
             json.dump(configuration, configuration_file, sort_keys=True, indent=2)
         configuration_file.write("\n")
 

--- a/client/commands/initialize.py
+++ b/client/commands/initialize.py
@@ -266,7 +266,7 @@ def get_configuration_and_path(
 def write_configuration(
     configuration: Dict[str, Any], configuration_path: Path
 ) -> None:
-    with open(configuration_path, "w+") as configuration_file:
+    with open(configuration_path, "wb+") as configuration_file:
         if configuration_path.suffix.lower() == ".toml":
             configuration = {"tool": {"pyre": configuration}}  # [tool.pyre] section
             tomli_w.dump(configuration, configuration_file)

--- a/client/commands/start.py
+++ b/client/commands/start.py
@@ -221,7 +221,7 @@ def get_critical_files(
         return str(full_path)
 
     # TODO(T137504540) update critical files for overridden configs as well
-    configuration_name = find_directories.CONFIGURATION_FILE
+    configuration_name = find_directories.JSON_CONFIGURATION_FILE
     local_root = configuration.get_local_root()
     return [
         CriticalFile(

--- a/client/configuration/tests/configuration_test.py
+++ b/client/configuration/tests/configuration_test.py
@@ -1216,7 +1216,10 @@ strict = false
                 self.assertEqual(
                     configuration_file.read(),
                     """[tool.pyre]
-exclude = ["sample/exclude1", "sample/exclude2"]
+excludes = [
+    "sample/exclude1",
+    "sample/exclude2",
+]
 strict = true
 """,
                 )

--- a/client/find_directories.py
+++ b/client/find_directories.py
@@ -24,7 +24,8 @@ import sys
 from pathlib import Path
 from typing import Callable, List, NamedTuple, Optional
 
-CONFIGURATION_FILE: str = ".pyre_configuration"
+JSON_CONFIGURATION_FILE: str = ".pyre_configuration"
+TOML_CONFIGURATION_FILE: str = "pyproject.toml"
 LOCAL_CONFIGURATION_FILE: str = ".pyre_configuration.local"
 BINARY_NAME: str = "pyre.bin"
 CLIENT_NAME: str = "pyre-client"
@@ -122,7 +123,7 @@ def find_outermost_directory_containing_file(
 def find_global_root(base: Path) -> Optional[Path]:
     """Pyre always runs from the directory containing the nearest .pyre_configuration,
     if one exists."""
-    return find_parent_directory_containing_file(base, CONFIGURATION_FILE)
+    return find_parent_directory_containing_file(base, JSON_CONFIGURATION_FILE) or find_parent_directory_containing_file(base, TOML_CONFIGURATION_FILE)
 
 
 def get_relative_local_root(
@@ -152,7 +153,9 @@ def find_global_and_local_root(base: Path) -> Optional[FoundRoot]:
     return the path to the global configuration.
     If both global and local exist, return them as a pair.
     """
-    found_global_root = find_parent_directory_containing_file(base, CONFIGURATION_FILE)
+    found_global_root = find_parent_directory_containing_file(
+        base, JSON_CONFIGURATION_FILE
+    ) or find_parent_directory_containing_file(base, TOML_CONFIGURATION_FILE)
     if found_global_root is None:
         return None
 

--- a/client/tests/setup.py
+++ b/client/tests/setup.py
@@ -35,7 +35,7 @@ from typing import (
 
 from pyre_extensions import ParameterSpecification
 
-from ..find_directories import CONFIGURATION_FILE, LOCAL_CONFIGURATION_FILE
+from ..find_directories import JSON_CONFIGURATION_FILE, LOCAL_CONFIGURATION_FILE
 
 TParams = ParameterSpecification("TParams")
 T = TypeVar("T")
@@ -59,7 +59,7 @@ def write_configuration_file(
     content: Mapping[str, Any],
     relative: Optional[str] = None,
 ) -> None:
-    configuration_file = CONFIGURATION_FILE
+    configuration_file = JSON_CONFIGURATION_FILE
     if relative is None:
         (root / configuration_file).write_text(json.dumps(content))
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,35 @@ excludes = [
     "stubs/",
     "pyre2/",
 ]
+
+[tool.pyre]
+exclude = [
+    ".*/documentation/.*",
+    ".*/generate_taint_models/.*",
+    ".*/scripts/.*",
+    ".*/source/.*",
+    ".*/pyre-check/stubs/.*",
+]
+ignore_all_errors = [
+    "client/tests/configuration_test.py",
+    "pyre_extensions/safe_json.py",
+]
+search_path = [
+    { site-package = "click" },
+    { site-package = "dataclasses_json" },
+    { site-package = "flask" },
+    { site-package = "flask_cors" },
+    { site-package = "graphql" },
+    { site-package = "libcst" },
+    { site-package = "marshmallow" },
+    { site-package = "psutil" },
+    { site-package = "testslide" },
+    { site-package = "toml" },
+    { site-package = "tabulate" },
+    { site-package = "tomli" },
+    { site-package = "tomli_w" },
+    { is_toplevel_module = true, site-package = "typing_extensions" },
+    { is_toplevel_module = true, site-package = "typing_inspect" },
+]
+source_directories = ["."]
+strict = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ tabulate
 testslide>=2.7.0
 typing_extensions
 typing_inspect
+tomli
+tomli-w

--- a/tools/upgrade/commands/strict_default.py
+++ b/tools/upgrade/commands/strict_default.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 from pyre_extensions import override
 
 from ....client.find_directories import (
-    CONFIGURATION_FILE,
+    JSON_CONFIGURATION_FILE,
     find_global_and_local_root,
     LOCAL_CONFIGURATION_FILE,
 )
@@ -43,7 +43,7 @@ def _get_configuration_path(local_configuration: Optional[Path]) -> Optional[Pat
         if local_root:
             return local_root / LOCAL_CONFIGURATION_FILE
         else:
-            return found_root.global_root / CONFIGURATION_FILE
+            return found_root.global_root / JSON_CONFIGURATION_FILE
 
 
 class StrictDefault(ErrorSuppressingCommand):


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
This PR resolves #695.
I'm not sure we should look for `pyproject.toml` silently when `.pyre_configuration` is not valid, or only look for it when a flag provided.But, I prefer the first resoulution because the second need to provide a flag in all runs.However, I want to hear you opinion.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Look for if the unittest passed.
As the unittest is not avalible this time(see footnote), I ran test in my local machine with python3.10:
![image](https://github.com/facebook/pyre-check/assets/120731947/fdc82209-5a35-4816-aa28-9c8d1766fba6)

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
Footnote: 
* GitHub Action workflow `Test` fails due to `match` statement is incompatible with Python3.8 and 3.9, and is not related to this PR.To make this easier to review and avoid confliting, I will rebase this PR on the top of main if the `match` statement refactored with `if-elif-else` statement but not do it in this PR.
* As a post-process, we need to delete unneeded `.pyre_configuration` at the root of this project after the nightly version of Pyre with this diff deployed.I intergrated configurations into `pyproject.toml`.
