### PR TITLE
Fix link to query docs

### DIFF
--- a/client/pyre.py
+++ b/client/pyre.py
@@ -1120,7 +1120,7 @@ def query(
     """
     Query a running Pyre server for type, function, and attribute information.
 
-    `https://pyre-check.org/docs/querying-pyre.html` contains examples and
+    `https://pyre-check.org/docs/querying-pyre/` contains examples and
     documentation for this command.
 
     To get a full list of queries, you can run `pyre query help`.


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Just fixes a link to the query docs. The link is shown when running `pyre query -h`
