### PR TITLE
Fix nondeterministic test by using `dict.fromkeys ~= orderedset`

### DIFF
--- a/client/commands/pyre_language_server.py
+++ b/client/commands/pyre_language_server.py
@@ -1282,7 +1282,8 @@ class PyreLanguageServer(PyreLanguageServerApi):
         2. Filtering out references that don't point to the same symbol
             a. References from an index can be stale and mispoint.
         """
-        deduped_references = list(set(references))
+        # Why `dict.fromkeys`? This is a trick to get ordered-set behavior in Python 3.7+
+        deduped_references = list(dict.fromkeys(references))
         code_text = self.server_state.opened_documents[document_path].code
         global_root = (
             self.server_state.server_options.start_arguments.base_arguments.global_root

--- a/client/commands/tests/language_server_test.py
+++ b/client/commands/tests/language_server_test.py
@@ -2862,11 +2862,11 @@ foo(10)
                     "changes": {
                         "file:///global/root/path/to/foo.py": [
                             lsp.TextEdit(
-                                range=local_test_range_2,
+                                range=local_test_range_1,
                                 new_text=test_text,
                             ),
                             lsp.TextEdit(
-                                range=local_test_range_1,
+                                range=local_test_range_2,
                                 new_text=test_text,
                             ),
                         ],


### PR DESCRIPTION
Summary:
For a number of weeks now I've been frustrated by github test failure
notifications. I dug into the root cause for BE day, and it is that we
are using `list(set(_))` to deduplicate two lists of references in
the find-references logic.

This is fine and correct, but also nondeterministic because `set` ordering
isn't fixed. There's no ordered set in the python standard library, and
it's not worth adding a dependency to get one. Instead, the standard trick
to work around this is to use a dict of `None` so the keys act like a set,
which solves the problem because in 3.7+ dict keys are ordered.

Differential Revision: D52662624


