### PR TITLE
Treat *.ml{i} in Linguist as OCaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Some files (see the screenshot below) are being incorrectly recognized as SML instead of OCaml by Linguist. This change explicitly marks *.ml{i} files as always OCaml for Linguist.

<img width="323" alt="Screenshot 2024-03-01 at 11 14 03" src="https://github.com/facebook/pyre-check/assets/1146876/d7fc7ac7-61fa-4b22-89ea-ba46bfe8dd39">

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
N/A
<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
