### PR TITLE
PEP 604: from __future__ import annotations

### DIFF
--- a/client/language_server/protocol.py
+++ b/client/language_server/protocol.py
@@ -14,7 +14,7 @@ to/from the persistent Pyre client (such as hover, definition, etc.)
 the LSP client. This currently involves doing some kind of transformation to/from a JSON string
 to the specific representation in class form.
 """
-
+from __future__ import annotations
 
 import asyncio
 import dataclasses


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Fixes #827
* #832
* https://github.com/facebook/pyre-check/issues/827#issuecomment-2075325725

Our GitHub Actions tests are failing on Python < 3.10 because of the use of PEP 604 syntax.
* PEP 604 – Allow writing union types as X | Y -- https://peps.python.org/pep-0604

## Test Plan

Get the GitHub Actions tests to pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
