### PR TITLE
Guard use of `dict[str, str]` for Python 3.8

### DIFF
--- a/client/commands/error_code_to_link_mapper.py
+++ b/client/commands/error_code_to_link_mapper.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 
 error_code_to_fragment: dict[int, str] = {
     0: "0-unused-ignore",


### PR DESCRIPTION
Summary:
Github tests caught another too-new-to-use feature in our Python code:
you cannot directly subscript builtin containers like `dict` until 3.9.

In this case since there's no runtime need for the annotation, we can
use `from __future__ import annotations` to work around the problem.

Differential Revision: D56821982
