### PR TITLE
Fix bad pipe operator in upgrade

### DIFF
--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # For open-source tests to work, we have to run them from one directory
 # higher than the project root, so that the project root is treated as a
@@ -18,7 +18,6 @@ cd "${SCRIPTS_DIRECTORY}/.."
 ROOT_DIRECTORY="$(pwd)"
 ROOT_DIRECTORY_BASE="$(basename "${ROOT_DIRECTORY}")"
 
-
 # run pyre-extensions tests first: we want to test lower-level code
 # first since higher-level test failures are less informative
 
@@ -29,13 +28,12 @@ echo "Found these test files in the pyre_extensions code:
 ${files}
 ---"
 if [[ -z "${files}" ]]; then
-  echo 'No test files found, exiting.'
-  exit 2
+	echo 'No test files found, exiting.'
+	exit 2
 fi
 
 echo ' Running all tests:'
 echo "${files}" | xargs testslide
-
 
 # Test pyre client code last since that's the highest-level code.
 
@@ -46,9 +44,13 @@ echo "Found these test files in the client code:
 ${files}
 ---"
 if [[ -z "${files}" ]]; then
-  echo 'No test files found, exiting.'
-  exit 2
+	echo 'No test files found, exiting.'
+	exit 2
 fi
 
 echo ' Running client tests:'
+echo "${files}" | xargs testslide
+
+files=$(find "${ROOT_DIRECTORY_BASE}/tools/upgrade" -name '*_test.py')
+echo ' Running upgrade tests:'
 echo "${files}" | xargs testslide

--- a/tools/upgrade/commands/configurationless.py
+++ b/tools/upgrade/commands/configurationless.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging

--- a/tools/upgrade/commands/strict_default.py
+++ b/tools/upgrade/commands/strict_default.py
@@ -9,6 +9,7 @@
 strict_default contains a library for running a codemod across a codebase that turns pyre-strict on. Optionally, we can also remove the #pyre-strict and add #pyre-unsafe headers from files where the error count is below a certain threshhold.
 """
 
+from __future__ import annotations
 
 import argparse
 import logging

--- a/tools/upgrade/configuration.py
+++ b/tools/upgrade/configuration.py
@@ -9,6 +9,7 @@
 TODO(T132414938) Add a module-level docstring
 """
 
+from __future__ import annotations
 
 import glob
 import json


### PR DESCRIPTION
Summary:
This is blocking an open source release.

Note: there's a test failure still in OSS in one of these tests.
We do need to fix that, but unlike using illegal-for-python-3.9
syntax it doesn't make Pyre unreleasable.

Differential Revision: D57218457


