### PR TITLE
Apply Github Actions security best practices - pinned hashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - name: Build the Website
       run: |
         cd documentation/website
@@ -23,7 +23,7 @@ jobs:
       run: echo "The time was ${{ env.OUTPUT_TIME }} (UTC)"
     - name: Deploy
       if: ${{ github.event_name == 'push' }}
-      uses: JamesIves/github-pages-deploy-action@releases/v4
+      uses: JamesIves/github-pages-deploy-action@ec9c88baef04b842ca6f0a132fd61c762aa6c1b0 # releases/v4
       with:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.x
 
@@ -32,13 +32,13 @@ jobs:
           pyre --output=sarif check > sarif.json
 
       - name: Expose SARIF Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: SARIF Results
           path: sarif.json
 
       - name: Upload SARIF Results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b7cec7526559c32f1616476ff32d17ba4c59b2d6 # v3.25.5
         with:
           sarif_file: sarif.json
 

--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.10"
 
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install ocaml ocaml-dune
 
       - name: Setup OCaml
-        uses: avsm/setup-ocaml@v2
+        uses: avsm/setup-ocaml@8ea37830f3b2c9f54178d255808ae377b5758062 # v2.2.9
         with:
           ocaml-compiler: 4.14.0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
         python: [3.8, 3.9, "3.10", 3.11, 3.12]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox

--- a/documentation/pysa_tutorial/Dockerfile
+++ b/documentation/pysa_tutorial/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98
 
 RUN apt-get update
 


### PR DESCRIPTION
## Security Fixes

### Pinned Dependencies

GitHub Action tags and Docker tags are mutable. This poses a security risk. GitHub's Security Hardening guide recommends pinning actions to full length commit.

- [GitHub Security Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
- OpenSSF rates this as a: Risk: **Medium (possible compromised dependencies)**

Example in this repo: publish_website.yml uses the following which could be modified:

`      uses: JamesIves/github-pages-deploy-action@releases/v4`

This PR makes this immutable by pinning it to a full length hash.

`       uses: JamesIves/github-pages-deploy-action@ec9c88baef04b842ca6f0a132fd61c762aa6c1b0 # releases/v4`

Github says directly that:

**Pin actions to a full length commit SHA**

_Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork._

This is especially important when using third-party actions.

I plan to submit another PR (assuming this one is merged) that implements the dependabot actions dependency review that creates PRs automatically to update actions to their newest versions to make this easier to manage. (For example, if a new version of `uses: JamesIves/github-pages-deploy-action` comes out.) Although it looks like you may already have this setup/partially setup.

### Secure Dockerfiles

Pin image tags to digests in Dockerfiles. With the Docker v2 API release, it became possible to use digests in place of tags when pulling images or to use them in FROM lines in Dockerfiles.

- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

This is the same thing as above, only for dockerfiles.

Lastly, if needed, I can break this down into file by file PRs.