### PR TITLE
Don't use patch for pyre in upgrade tests [2/n]

### DIFF
--- a/tools/upgrade/commands/tests/command_test.py
+++ b/tools/upgrade/commands/tests/command_test.py
@@ -102,7 +102,7 @@ class CommandTest(unittest.TestCase):
             ]
         )
 
-    @patch(f"{command.__name__}.add_local_mode")
+    @patch.object(command, "add_local_mode")
     def test_get_and_suppress_errors(self, add_local_mode) -> None:
         arguments = MagicMock()
         repository = MagicMock()

--- a/tools/upgrade/commands/tests/consolidate_nested_configurations_test.py
+++ b/tools/upgrade/commands/tests/consolidate_nested_configurations_test.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import call, MagicMock, patch
 
 from ... import errors
+from ...configuration import Configuration
 from ...repository import Repository
 from .. import consolidate_nested_configurations
 from ..consolidate_nested_configurations import (
@@ -50,8 +51,8 @@ class ConsolidateNestedConfigurationsTest(unittest.TestCase):
         ).gather_nested_configuration_mapping(configurations)
         self.assertEqual(expected_mapping, mapping)
 
-    @patch(f"{consolidate_nested_configurations.__name__}.Repository.remove_paths")
-    @patch(f"{consolidate_nested_configurations.__name__}.Configuration.get_errors")
+    @patch.object(Repository, "remove_paths")
+    @patch.object(Configuration, "get_errors")
     def test_consolidate(self, get_errors, remove_paths) -> None:
         get_errors.return_value = errors.Errors([])
         with tempfile.TemporaryDirectory() as root:
@@ -89,8 +90,8 @@ class ConsolidateNestedConfigurationsTest(unittest.TestCase):
                     {"targets": ["//x/...", "//a/...", "//b/..."]},
                 )
 
-    @patch(f"{consolidate_nested_configurations.__name__}.Repository.commit_changes")
-    @patch(f"{consolidate_nested_configurations.__name__}.consolidate_nested")
+    @patch.object(Repository, "commit_changes")
+    @patch.object(consolidate_nested_configurations, "consolidate_nested")
     def test_run_skip(self, consolidate, commit_changes) -> None:
         with tempfile.TemporaryDirectory() as root:
             arguments = MagicMock()
@@ -109,9 +110,9 @@ class ConsolidateNestedConfigurationsTest(unittest.TestCase):
                 ).run()
                 consolidate.assert_not_called()
 
-    @patch(f"{consolidate_nested_configurations.__name__}.Repository.commit_changes")
-    @patch(f"{consolidate_nested_configurations.__name__}.consolidate_nested")
-    @patch(f"{consolidate_nested_configurations.__name__}.Configuration.get_errors")
+    @patch.object(Repository, "commit_changes")
+    @patch.object(consolidate_nested_configurations, "consolidate_nested")
+    @patch.object(Configuration, "get_errors")
     def test_run_topmost(self, get_errors, consolidate, commit_changes) -> None:
         with tempfile.TemporaryDirectory() as root:
             arguments = MagicMock()
@@ -140,9 +141,9 @@ class ConsolidateNestedConfigurationsTest(unittest.TestCase):
                     sorted([Path(nested_a.name), Path(nested_b.name)]),
                 )
 
-    @patch(f"{consolidate_nested_configurations.__name__}.Repository.commit_changes")
-    @patch(f"{consolidate_nested_configurations.__name__}.consolidate_nested")
-    @patch(f"{consolidate_nested_configurations.__name__}.Configuration.get_errors")
+    @patch.object(Repository, "commit_changes")
+    @patch.object(consolidate_nested_configurations, "consolidate_nested")
+    @patch.object(Configuration, "get_errors")
     def test_run_no_topmost(self, get_errors, consolidate, commit_changes) -> None:
         with tempfile.TemporaryDirectory() as root:
             arguments = MagicMock()

--- a/tools/upgrade/commands/tests/expand_target_coverage_test.py
+++ b/tools/upgrade/commands/tests/expand_target_coverage_test.py
@@ -10,6 +10,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import call, MagicMock, mock_open, patch
 
+from ...configuration import Configuration
+
 from ...repository import Repository
 from .. import expand_target_coverage
 from ..expand_target_coverage import ErrorSuppressingCommand, ExpandTargetCoverage
@@ -20,12 +22,12 @@ repository = Repository()
 
 class ExpandTargetCoverageTest(unittest.TestCase):
     @patch("builtins.open")
-    @patch(f"{expand_target_coverage.__name__}.Repository.commit_changes")
-    @patch(f"{expand_target_coverage.__name__}.Configuration.find_local_configuration")
-    @patch(f"{expand_target_coverage.__name__}.Configuration.deduplicate_targets")
+    @patch.object(Repository, "commit_changes")
+    @patch.object(Configuration, "find_local_configuration")
+    @patch.object(Configuration, "deduplicate_targets")
     @patch.object(ErrorSuppressingCommand, "_get_and_suppress_errors")
-    @patch(f"{expand_target_coverage.__name__}.Repository.format")
-    @patch(f"{expand_target_coverage.__name__}.find_files")
+    @patch.object(Repository, "format")
+    @patch.object(expand_target_coverage, "find_files")
     def test_run_expand_target_coverage(
         self,
         find_files,

--- a/tools/upgrade/commands/tests/fix_configuration_test.py
+++ b/tools/upgrade/commands/tests/fix_configuration_test.py
@@ -13,7 +13,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from ... import upgrade
 from ...repository import Repository
 from ..fix_configuration import Configuration, FixConfiguration
 
@@ -33,8 +32,8 @@ def _raise_on_bad_target(build_command, timeout) -> str:
 class FixmeConfigurationTest(unittest.TestCase):
     @patch("subprocess.check_output")
     @patch.object(Configuration, "get_errors")
-    @patch(f"{upgrade.__name__}.Repository.commit_changes")
-    @patch(f"{upgrade.__name__}.Repository.remove_paths")
+    @patch.object(Repository, "commit_changes")
+    @patch.object(Repository, "remove_paths")
     def test_run_fix_configuration(
         self, remove_paths, commit_changes, get_errors, check_output
     ) -> None:

--- a/tools/upgrade/commands/tests/fixme_all_test.py
+++ b/tools/upgrade/commands/tests/fixme_all_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
+# . Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import call, MagicMock, mock_open, patch
 
 from ... import upgrade
+from ...errors import Errors
 from ...repository import Repository
 from .. import command
 from ..command import ErrorSource, ErrorSuppressingCommand
@@ -118,10 +119,10 @@ class FixmeAllTest(unittest.TestCase):
     @patch.object(Configuration, "remove_version")
     @patch.object(Configuration, "get_errors")
     @patch.object(Configuration, "gather_local_configurations")
-    @patch(f"{command.__name__}.Errors.from_stdin")
+    @patch.object(Errors, "from_stdin")
     @patch.object(upgrade.GlobalVersionUpdate, "run")
     @patch.object(ErrorSuppressingCommand, "_apply_suppressions")
-    @patch(f"{upgrade.__name__}.Repository.format")
+    @patch.object(Repository, "format")
     def test_upgrade_project(
         self,
         repository_format,
@@ -218,7 +219,7 @@ class FixmeAllTest(unittest.TestCase):
     @patch.object(Configuration, "get_errors")
     @patch.object(upgrade.GlobalVersionUpdate, "run")
     @patch.object(ErrorSuppressingCommand, "_apply_suppressions")
-    @patch(f"{upgrade.__name__}.Repository.commit_changes")
+    @patch.object(Repository, "commit_changes")
     def test_run_fixme_all(
         self,
         commit_changes,

--- a/tools/upgrade/commands/tests/fixme_single_test.py
+++ b/tools/upgrade/commands/tests/fixme_single_test.py
@@ -26,7 +26,7 @@ class FixmeSingleTest(unittest.TestCase):
     @patch.object(Configuration, "remove_version")
     @patch.object(Configuration, "get_errors")
     @patch.object(ErrorSuppressingCommand, "_get_and_suppress_errors")
-    @patch(f"{upgrade.__name__}.Repository.commit_changes")
+    @patch.object(Repository, "commit_changes")
     def test_run_fixme_single(
         self,
         commit_changes: MagicMock,

--- a/tools/upgrade/commands/tests/strict_default_test.py
+++ b/tools/upgrade/commands/tests/strict_default_test.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 from ...filesystem import LocalMode
 from ...repository import Repository
+
 from .. import strict_default
 from ..strict_default import (
     _get_configuration_path,
@@ -27,7 +28,7 @@ repository = Repository()
 
 class StrictDefaultTest(unittest.TestCase):
     @patch.object(Configuration, "get_source_paths")
-    @patch(f"{strict_default.__name__}.remove_local_mode")
+    @patch.object(strict_default, "remove_local_mode")
     @patch.object(strict_default, "_get_configuration_path", return_value=Path("."))
     @patch.object(Configuration, "get_directory")
     @patch.object(Configuration, "write")
@@ -65,7 +66,7 @@ class StrictDefaultTest(unittest.TestCase):
             get_and_suppress_errors.assert_called_once()
 
     @patch.object(Configuration, "get_source_paths")
-    @patch(f"{strict_default.__name__}.remove_local_mode")
+    @patch.object(strict_default, "remove_local_mode")
     @patch.object(strict_default, "_get_configuration_path", return_value=Path("."))
     @patch.object(Configuration, "get_directory")
     @patch.object(Configuration, "write")
@@ -98,7 +99,7 @@ class StrictDefaultTest(unittest.TestCase):
             )
 
     @patch.object(Configuration, "get_source_paths")
-    @patch(f"{strict_default.__name__}.remove_local_mode")
+    @patch.object(strict_default, "remove_local_mode")
     @patch.object(strict_default, "_get_configuration_path", return_value=Path("."))
     @patch.object(Configuration, "get_directory")
     @patch.object(Configuration, "write")
@@ -132,7 +133,7 @@ class StrictDefaultTest(unittest.TestCase):
             )
 
     @patch.object(Configuration, "get_source_paths")
-    @patch(f"{strict_default.__name__}.remove_local_mode")
+    @patch.object(strict_default, "remove_local_mode")
     @patch.object(strict_default, "_get_configuration_path", return_value=Path("."))
     @patch.object(Configuration, "get_directory")
     @patch.object(Configuration, "write")
@@ -164,7 +165,7 @@ class StrictDefaultTest(unittest.TestCase):
             )
 
     @patch.object(Configuration, "get_source_paths")
-    @patch(f"{strict_default.__name__}.remove_local_mode")
+    @patch.object(strict_default, "remove_local_mode")
     @patch.object(strict_default, "_get_configuration_path", return_value=Path("."))
     @patch.object(Configuration, "get_directory")
     @patch.object(Configuration, "write")

--- a/tools/upgrade/commands/tests/targets_to_configuration_test.py
+++ b/tools/upgrade/commands/tests/targets_to_configuration_test.py
@@ -20,6 +20,7 @@ from .. import targets_to_configuration
 from ..targets_to_configuration import (
     Configuration,
     ErrorSuppressingCommand,
+    StrictDefault,
     TargetPyreRemover,
     TargetsToConfiguration,
 )
@@ -136,20 +137,18 @@ class TargetRemoverTest(unittest.TestCase):
 
 class TargetsToConfigurationTest(unittest.TestCase):
     @patch("builtins.open")
-    @patch(f"{targets_to_configuration.__name__}.Repository.revert_all")
-    @patch(f"{targets_to_configuration.__name__}.Repository.add_paths")
-    @patch(f"{targets_to_configuration.__name__}.find_targets")
-    @patch(f"{targets_to_configuration.__name__}.get_filesystem")
+    @patch.object(Repository, "revert_all")
+    @patch.object(Repository, "add_paths")
+    @patch.object(targets_to_configuration, "find_targets")
+    @patch.object(targets_to_configuration, "get_filesystem")
     @patch.object(Path, "exists")
-    @patch(f"{targets_to_configuration.__name__}.remove_non_pyre_ignores")
-    @patch(f"{targets_to_configuration.__name__}.Configuration.get_errors")
-    @patch(f"{targets_to_configuration.__name__}.add_local_mode")
+    @patch.object(targets_to_configuration, "remove_non_pyre_ignores")
+    @patch.object(Configuration, "get_errors")
+    @patch.object(targets_to_configuration, "add_local_mode")
     @patch.object(ErrorSuppressingCommand, "_apply_suppressions")
-    @patch(f"{targets_to_configuration.__name__}.Repository.format")
-    @patch(
-        f"{targets_to_configuration.__name__}.TargetsToConfiguration.remove_target_typing_fields"
-    )
-    @patch(f"{targets_to_configuration.__name__}.StrictDefault.run")
+    @patch.object(Repository, "format")
+    @patch.object(TargetsToConfiguration, "remove_target_typing_fields")
+    @patch.object(StrictDefault, "run")
     def test_convert_directory(
         self,
         run_strict_default,
@@ -372,8 +371,8 @@ class TargetsToConfigurationTest(unittest.TestCase):
             remove_target_typing_fields.assert_called_once()
             run_strict_default.assert_not_called()
 
-    @patch(f"{targets_to_configuration.__name__}.find_files")
-    @patch(f"{targets_to_configuration.__name__}.find_directories")
+    @patch.object(targets_to_configuration, "find_files")
+    @patch.object(targets_to_configuration, "find_directories")
     def test_gather_directories(self, find_directories, find_files) -> None:
         arguments = MagicMock()
         find_files.return_value = ["subdirectory/.pyre_configuration.local"]

--- a/tools/upgrade/tests/errors_test.py
+++ b/tools/upgrade/tests/errors_test.py
@@ -99,7 +99,7 @@ class ErrorsTest(unittest.TestCase):
     @patch.object(errors.Path, "write_text")
     def test_suppress(self, path_write_text, path_read_text) -> None:
         # Test run on multiple files.
-        with patch(f"{errors.__name__}._suppress_errors", return_value="<transformed>"):
+        with patch.object(errors, "_suppress_errors", return_value="<transformed>"):
             Errors(
                 [
                     {
@@ -119,7 +119,7 @@ class ErrorsTest(unittest.TestCase):
                 [call("<transformed>"), call("<transformed>")]
             )
 
-        with patch(f"{errors.__name__}._suppress_errors", side_effect=UnstableAST()):
+        with patch.object(errors, "_suppress_errors", side_effect=UnstableAST()):
             with self.assertRaises(PartialErrorSuppression) as context:
                 Errors(
                     [


### PR DESCRIPTION
Summary:
This is the second of two commits removing the use of
`unittest.patch` on pyre-internal functions and classes;
instead we need to always use `patch.object` to avoid getting
errors on invalid names in github CI.

Differential Revision: D57359461


