### PR TITLE
Remove dead `pyre-ignore` directives

### DIFF
--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
           pip install cython flask flask_cors graphql-core typing_inspect
           VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
           pip install pyre-check-nightly==$VERSION
@@ -29,7 +30,7 @@ jobs:
       - name: Run Pyre
         continue-on-error: true
         run: |
-          pyre --output=sarif check > sarif.json
+          pyre -n --output=sarif check > sarif.json
 
       - name: Expose SARIF Results
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -42,6 +42,12 @@
       "site-package": "testslide"
     },
     {
+      "site-package": "toml"
+    },
+    {
+      "site-package": "tabulate"
+    },
+    {
       "is_toplevel_module": true,
       "site-package": "typing_extensions"
     },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pre-commit
+toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=8.0
-dataclasses-json
+dataclasses-json==0.5.7
 intervaltree
 libcst
 psutil

--- a/tools/typeshed_patcher/typeshed.py
+++ b/tools/typeshed_patcher/typeshed.py
@@ -57,8 +57,6 @@ class Typeshed(abc.ABC):
     Representation of a collection of Python stub files.
     """
 
-    # pyre-fixme[56]: Pyre doesn't yet support decorators with ParamSpec applied to
-    #  generic functions Please add # pyre-ignore[56] to `abc.abstractclassmethod`.
     @abc.abstractclassmethod
     def get_file_content(self, path: pathlib.Path) -> Optional[str]:
         """
@@ -69,8 +67,6 @@ class Typeshed(abc.ABC):
         """
         raise NotImplementedError()
 
-    # pyre-fixme[56]: Pyre doesn't yet support decorators with ParamSpec applied to
-    #  generic functions Please add # pyre-ignore[56] to `abc.abstractclassmethod`.
     @abc.abstractclassmethod
     def all_files(self) -> Iterable[pathlib.Path]:
         """

--- a/tools/upgrade/commands/tests/fixme_all_test.py
+++ b/tools/upgrade/commands/tests/fixme_all_test.py
@@ -9,12 +9,10 @@ import json
 import subprocess
 import unittest
 from pathlib import Path
-from unittest.mock import call, MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from ... import upgrade
-from ...errors import Errors
 from ...repository import Repository
-from .. import command
 from ..command import ErrorSource, ErrorSuppressingCommand
 from ..fixme_all import Configuration, FixmeAll
 

--- a/tools/upgrade/commands/tests/fixme_single_test.py
+++ b/tools/upgrade/commands/tests/fixme_single_test.py
@@ -9,7 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
-from ... import upgrade
 from ...errors import Errors
 from ...repository import Repository
 from ..command import ErrorSuppressingCommand


### PR DESCRIPTION
Summary:
The dataclasses-json version we are getting in github has types that
are incompatible with the internal version. As a result, we need to pin
the version on github to get comparable results (in addition it's at
least possible we would get bugs in open-source without pinning). I
filed T189226004 to bump the version internally.

In addition:
- we aren't marking `toml` as a dependency, but we need it as a dev
  dependency because type checking the typeshed patcher requires it
- we need to list both tabulate and toml in our .pyre_configuration
  for github to pick them up because we are still using the legacy
	setup where packages aren't picked up by default... this would
	probably be good to change at some point.

Differential Revision: D57433947


