### PR TITLE
Update full_result.json

### DIFF
--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
           pip install cython flask flask_cors graphql-core typing_inspect
           VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
           pip install pyre-check-nightly==$VERSION
@@ -29,7 +30,7 @@ jobs:
       - name: Run Pyre
         continue-on-error: true
         run: |
-          pyre --output=sarif check > sarif.json
+          pyre -n --output=sarif check > sarif.json
 
       - name: Expose SARIF Results
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -42,6 +42,12 @@
       "site-package": "testslide"
     },
     {
+      "site-package": "toml"
+    },
+    {
+      "site-package": "tabulate"
+    },
+    {
       "is_toplevel_module": true,
       "site-package": "typing_extensions"
     },

--- a/documentation/deliberately_vulnerable_flask_app/full_result.json
+++ b/documentation/deliberately_vulnerable_flask_app/full_result.json
@@ -45,17 +45,6 @@
   },
   {
     "line": 52,
-    "column": 53,
-    "stop_line": 52,
-    "stop_column": 60,
-    "path": "app.py",
-    "code": 5045,
-    "name": "SQL injection.",
-    "description": "SQL injection. [5045]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeSQL[main]]] sink(s)",
-    "define": "app.definite_sql"
-  },
-  {
-    "line": 52,
     "column": 16,
     "stop_line": 52,
     "stop_column": 62,
@@ -78,17 +67,6 @@
   },
   {
     "line": 45,
-    "column": 27,
-    "stop_line": 45,
-    "stop_column": 34,
-    "path": "app.py",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "app.definite_xss"
-  },
-  {
-    "line": 45,
     "column": 4,
     "stop_line": 45,
     "stop_column": 35,
@@ -97,28 +75,6 @@
     "name": "User input returned to user",
     "description": "User input returned to user [5015]: Data from [UserControlled] source(s) may reach [ReturnedToUser] sink(s)",
     "define": "app.definite_xss"
-  },
-  {
-    "line": 81,
-    "column": 13,
-    "stop_line": 81,
-    "stop_column": 20,
-    "path": "app.py",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "app.open_redirect_tp"
-  },
-  {
-    "line": 81,
-    "column": 13,
-    "stop_line": 81,
-    "stop_column": 20,
-    "path": "app.py",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "app.open_redirect_tp"
   },
   {
     "line": 28,
@@ -141,17 +97,6 @@
     "name": "Commandline arguments injection may result in RCE",
     "description": "Commandline arguments injection may result in RCE [6065]: Data from [UserControlled] source(s) may reach [ExecArgSink] sink(s)",
     "define": "app.potential_rce_2"
-  },
-  {
-    "line": 100,
-    "column": 28,
-    "stop_line": 100,
-    "stop_column": 35,
-    "path": "app.py",
-    "code": 6462,
-    "name": "User-controlled data flows into URL-like string (potential SSRF)",
-    "description": "User-controlled data flows into URL-like string (potential SSRF) [6462]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeURL[main]]] sink(s)",
-    "define": "app.user_controlled_data_flows_into_url_like_string_tp"
   },
   {
     "line": 90,
@@ -207,137 +152,5 @@
     "name": "Environment variable or import injection may result in RCE",
     "description": "Environment variable or import injection may result in RCE [6064]: Data from [UserControlled] source(s) may reach [ExecImportSink] sink(s)",
     "define": "app.user_data_to_getattr_tp"
-  },
-  {
-    "line": 497,
-    "column": 35,
-    "stop_line": 497,
-    "stop_column": 39,
-    "path": "*",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "flask.app.Flask.__init__"
-  },
-  {
-    "line": 497,
-    "column": 35,
-    "stop_line": 497,
-    "stop_column": 39,
-    "path": "*",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "flask.app.Flask.__init__"
-  },
-  {
-    "line": 1487,
-    "column": 37,
-    "stop_line": 1487,
-    "stop_column": 39,
-    "path": "*",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "flask.app.Flask.full_dispatch_request"
-  },
-  {
-    "line": 1487,
-    "column": 37,
-    "stop_line": 1487,
-    "stop_column": 39,
-    "path": "*",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "flask.app.Flask.full_dispatch_request"
-  },
-  {
-    "line": 1487,
-    "column": 37,
-    "stop_line": 1487,
-    "stop_column": 39,
-    "path": "*",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "flask.app.Flask.full_dispatch_request"
-  },
-  {
-    "line": 1487,
-    "column": 37,
-    "stop_line": 1487,
-    "stop_column": 39,
-    "path": "*",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "flask.app.Flask.full_dispatch_request"
-  },
-  {
-    "line": 2005,
-    "column": 48,
-    "stop_line": 2005,
-    "stop_column": 52,
-    "path": "*",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "flask.app.Flask.process_response"
-  },
-  {
-    "line": 2005,
-    "column": 48,
-    "stop_line": 2005,
-    "stop_column": 52,
-    "path": "*",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "flask.app.Flask.process_response"
-  },
-  {
-    "line": 2189,
-    "column": 16,
-    "stop_line": 2189,
-    "stop_column": 19,
-    "path": "*",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "flask.app.Flask.wsgi_app"
-  },
-  {
-    "line": 2206,
-    "column": 12,
-    "stop_line": 2206,
-    "stop_column": 15,
-    "path": "*",
-    "code": 5046,
-    "name": "XSS",
-    "description": "XSS [5046]: Data from [UserControlled] source(s) may reach [TriggeredPartialSink[UserControlledAndStringMayBeHTML[main]]] sink(s)",
-    "define": "flask.app.Flask.wsgi_app"
-  },
-  {
-    "line": 2189,
-    "column": 16,
-    "stop_line": 2189,
-    "stop_column": 19,
-    "path": "*",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "flask.app.Flask.wsgi_app"
-  },
-  {
-    "line": 2206,
-    "column": 12,
-    "stop_line": 2206,
-    "stop_column": 15,
-    "path": "*",
-    "code": 5018,
-    "name": "Open redirect",
-    "description": "Open redirect [5018]: Data from [UserControlled] source(s) may be used in an open redirect via [Redirect] sink(s)",
-    "define": "flask.app.Flask.wsgi_app"
   }
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pre-commit
+toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=8.0
-dataclasses-json
+dataclasses-json==0.5.7
 intervaltree
 libcst
 psutil

--- a/tools/typeshed_patcher/typeshed.py
+++ b/tools/typeshed_patcher/typeshed.py
@@ -57,8 +57,6 @@ class Typeshed(abc.ABC):
     Representation of a collection of Python stub files.
     """
 
-    # pyre-fixme[56]: Pyre doesn't yet support decorators with ParamSpec applied to
-    #  generic functions Please add # pyre-ignore[56] to `abc.abstractclassmethod`.
     @abc.abstractclassmethod
     def get_file_content(self, path: pathlib.Path) -> Optional[str]:
         """
@@ -69,8 +67,6 @@ class Typeshed(abc.ABC):
         """
         raise NotImplementedError()
 
-    # pyre-fixme[56]: Pyre doesn't yet support decorators with ParamSpec applied to
-    #  generic functions Please add # pyre-ignore[56] to `abc.abstractclassmethod`.
     @abc.abstractclassmethod
     def all_files(self) -> Iterable[pathlib.Path]:
         """

--- a/tools/upgrade/commands/tests/fixme_all_test.py
+++ b/tools/upgrade/commands/tests/fixme_all_test.py
@@ -9,12 +9,10 @@ import json
 import subprocess
 import unittest
 from pathlib import Path
-from unittest.mock import call, MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from ... import upgrade
-from ...errors import Errors
 from ...repository import Repository
-from .. import command
 from ..command import ErrorSource, ErrorSuppressingCommand
 from ..fixme_all import Configuration, FixmeAll
 

--- a/tools/upgrade/commands/tests/fixme_single_test.py
+++ b/tools/upgrade/commands/tests/fixme_single_test.py
@@ -9,7 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
-from ... import upgrade
 from ...errors import Errors
 from ...repository import Repository
 from ..command import ErrorSuppressingCommand


### PR DESCRIPTION
Summary:
This updates to what we are currently seeing in the integration tests.

There is a regression here: we don't seem to be resolving
werkzeug.utils.redirect properly; Maxime was able to verify that
reveal_type(redirect) comes back as `unknown`.

It's likely that this is either Pyre not finding the package due to some
configuration handling change, or a signature extraction issue.

I filed T189346515 to investigate, but it seems wise to make CI pass
in the meantime so that we'll notice the next regression quicker.

Differential Revision: D57437213


