### PR TITLE
enhanced the registry module to support pretty printing and string co…

### DIFF
--- a/source/interprocedural/fixpointAnalysis.ml
+++ b/source/interprocedural/fixpointAnalysis.ml
@@ -164,9 +164,22 @@ module Make (Analysis : ANALYSIS) = struct
 
     let get target registry = Target.Map.find_opt registry target
 
+    (* Pretty-print function for the registry *)
+    let pp formatter registry =
+      let pp_pair formatter (key, value) =
+        Format.fprintf formatter "@[%a -> %a@]" Target.pp key Model.pp value
+      in
+      let pp_pairs formatter pairs =
+        Format.pp_print_list pp_pair formatter (Target.Map.bindings registry)
+      in
+      Format.fprintf formatter "@[<v 2>{%a}@]" pp_pairs
+
+    (* Show function for the registry *)
+    let show = Format.asprintf "%a" pp
+  end
+
     let merge ~join left right =
       Target.Map.union (fun _ left right -> Some (join left right)) left right
-
 
     let of_alist ~join = Target.Map.of_alist ~f:join
 

--- a/source/interprocedural_analyses/taint/registry.ml
+++ b/source/interprocedural_analyses/taint/registry.ml
@@ -21,7 +21,7 @@ let targets_with_mode models ~mode =
   in
   fold ~init:[] ~f:collect models
 
-
+  
 let skip_overrides models =
   targets_with_mode models ~mode:Model.Mode.SkipOverrides
   |> List.filter ~f:Target.is_function_or_method
@@ -38,3 +38,15 @@ let skip_analysis models =
 
 
 let entrypoints models = targets_with_mode models ~mode:Model.Mode.Entrypoint
+
+let pp pp_value formatter map =
+  let pp_pairs formatter pairs =
+    let pp_pair formatter (key, value) =
+      Format.fprintf formatter "@[<hv 2>%a -> %a@]" Target.pp key pp_value value
+    in
+    Format.pp_print_list pp_pair formatter (Target.Map.bindings map)
+  in
+  Format.fprintf formatter "@[<v 2>{%a}@]" pp_pairs
+
+let show pp_value map =
+  Format.asprintf "%a" (pp pp_value) map

--- a/source/interprocedural_analyses/taint/registry.ml
+++ b/source/interprocedural_analyses/taint/registry.ml
@@ -21,7 +21,7 @@ let targets_with_mode models ~mode =
   in
   fold ~init:[] ~f:collect models
 
-  
+
 let skip_overrides models =
   targets_with_mode models ~mode:Model.Mode.SkipOverrides
   |> List.filter ~f:Target.is_function_or_method
@@ -38,15 +38,3 @@ let skip_analysis models =
 
 
 let entrypoints models = targets_with_mode models ~mode:Model.Mode.Entrypoint
-
-let pp pp_value formatter map =
-  let pp_pairs formatter pairs =
-    let pp_pair formatter (key, value) =
-      Format.fprintf formatter "@[<hv 2>%a -> %a@]" Target.pp key pp_value value
-    in
-    Format.pp_print_list pp_pair formatter (Target.Map.bindings map)
-  in
-  Format.fprintf formatter "@[<v 2>{%a}@]" pp_pairs
-
-let show pp_value map =
-  Format.asprintf "%a" (pp pp_value) map


### PR DESCRIPTION
#869 

This pull request adds pp and show functions to the Registry module to enable pretty-printing of the map contents for easier debugging and logging.

Changes:

**Added pp Function:**

The pp function formats the map's key-value pairs for pretty-printing.
Utilizes Format.fprintf for formatting and printing the map contents in a readable format.

**Added show Function:**

The show function converts the map to a string representation using the pp function.

Uses Format.asprintf to generate the string representation of the map.

**Modified File:**

registry.ml

**The pull request is not fully done. Please provide any feedback on if I have the general understanding of the Issue. I will then implement the feedback and attempt to tackle the entire issue.**