### PR TITLE
Warning messages about max number of overrides for beginners 

### DIFF
--- a/documentation/pysa_tutorial/exercise1/taint.config
+++ b/documentation/pysa_tutorial/exercise1/taint.config
@@ -23,5 +23,9 @@
       "sinks": [ "CodeExecution" ],
       "message_format": "User specified data may reach a code execution sink"
     }
-  ]
+  ],
+
+  "maximum_overrides_to_analyze": 30
 }
+
+

--- a/documentation/pysa_tutorial/exercise2/taint.config
+++ b/documentation/pysa_tutorial/exercise2/taint.config
@@ -27,5 +27,7 @@
       "sinks": [ "CodeExecution" ],
       "message_format": "User specified data may reach a code execution sink"
     }
-  ]
+  ],
+
+  "maximum_overrides_to_analyze": 30
 }

--- a/documentation/pysa_tutorial/exercise4/taint.config
+++ b/documentation/pysa_tutorial/exercise4/taint.config
@@ -4,8 +4,9 @@
   "features": [
     {
       "name": "example",
-      "comment": "Copy this feature and write your own. Don't forget that JSON lists are comma seperated!"
+      "comment": "Copy this feature and write your own. Don't forget that JSON lists are comma separated!"
     }
   ],
-  "rules": []
+  "rules": [],
+  "maximum_overrides_to_analyze": 30
 }


### PR DESCRIPTION
#870 

This pull request addresses the issue of warnings related to classes with a high number of overrides in Pysa. It includes the following changes:

**Update Override Warning Messages:**

Enhanced the warning messages for classes with many overrides to include a suggestion to use the maximum_overrides_to_analyze option.
Added a link to the relevant documentation for further guidance.

**Configuration Updates:**

Added the maximum_overrides_to_analyze option to the taint.config files for different exercises to improve analysis performance and reduce warning messages.

**Please provide any feedback as comments for this pull request. I will then apply the feedback and update the code. **