### PR TITLE
fixed a small issue with the installation page of the website 

### DIFF
--- a/documentation/website/docs/installation.md
+++ b/documentation/website/docs/installation.md
@@ -43,6 +43,7 @@ This will compile Pyre and run all the unit tests. This is likely going to take 
 
 You can now make changes to the code. Run the following commands to compile and test your changes:
 ```bash
+$ cd source
 $ make
 $ make test
 ```


### PR DESCRIPTION
In the website installation page, we actually have to cd into the source folder before we can call make as the make file in located in the source folder. 