### PR TITLE
added show to registry

### DIFF
--- a/source/interprocedural/fixpointAnalysis.ml
+++ b/source/interprocedural/fixpointAnalysis.ml
@@ -163,6 +163,30 @@ module Make (Analysis : ANALYSIS) = struct
 
 
     let get target registry = Target.Map.find_opt registry target
+    
+    (* Pretty-print function for the registry *)
+    let pp formatter registry =
+      let pp_pair formatter (key, value) =
+        Format.fprintf formatter "@[%a -> %a@]" Target.pp key Model.pp value
+      in
+      let pp_pairs formatter pairs =
+        Format.pp_print_list pp_pair formatter (Target.Map.bindings registry)
+      in
+      Format.fprintf formatter "@[<v 2>{%a}@]" pp_pairs
+  
+    (* Show function for the registry *)
+    let show = Format.asprintf "%a" pp
+  end
+  
+  (* Temporary code to demonstrate pretty-printing *)
+  let () =
+    (* Create example target and model *)
+    let target = Target.make_target "example_target"  (* Use actual creation method for target *)
+    and model = Model.make_model "example_model" (* Use actual creation method for model *) in
+    let registry = Registry.singleton ~target ~model in
+    (* Print the registry contents *)
+    Format.printf "%s\n" (Registry.show registry)
+
 
     let merge ~join left right =
       Target.Map.union (fun _ left right -> Some (join left right)) left right

--- a/source/interprocedural/fixpointAnalysis.ml
+++ b/source/interprocedural/fixpointAnalysis.ml
@@ -177,16 +177,6 @@ module Make (Analysis : ANALYSIS) = struct
     (* Show function for the registry *)
     let show = Format.asprintf "%a" pp
   end
-  
-  (* Temporary code to demonstrate pretty-printing *)
-  let () =
-    (* Create example target and model *)
-    let target = Target.make_target "example_target"  (* Use actual creation method for target *)
-    and model = Model.make_model "example_model" (* Use actual creation method for model *) in
-    let registry = Registry.singleton ~target ~model in
-    (* Print the registry contents *)
-    Format.printf "%s\n" (Registry.show registry)
-
 
     let merge ~join left right =
       Target.Map.union (fun _ left right -> Some (join left right)) left right
@@ -898,3 +888,13 @@ struct
     else
       Format.ifprintf Format.err_formatter format
 end
+
+ 
+(* Temporary code to demonstrate pretty-printing *)
+let () =
+  (* Create example target and model *)
+  let target = Target.make_target "example_target"  (* Use actual creation method for target *)
+  and model = Model.make_model "example_model" (* Use actual creation method for model *) in
+  let registry = Registry.singleton ~target ~model in
+  (* Print the registry contents *)
+  Format.printf "%s\n" (Registry.show registry)


### PR DESCRIPTION
#869 

This pull request adds pp and show functions to the Registry module to enable pretty-printing of the map contents for easier debugging and logging.

Changes:

Added pp Function:

The pp function formats the map's key-value pairs for pretty-printing.
Utilizes Format.fprintf for formatting and printing the map contents in a readable format.

Added show Function:

The show function converts the map to a string representation using the pp function.

Uses Format.asprintf to generate the string representation of the map.