### PR TITLE
Try fixing github build: install only opam with apt

### DIFF
--- a/.github/workflows/pysa.yml
+++ b/.github/workflows/pysa.yml
@@ -21,23 +21,24 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install -r requirements.txt
-          sudo apt-get install ocaml ocaml-dune
-
-      - name: Setup OCaml
-        uses: avsm/setup-ocaml@8cc6339f55862749298d198ef84788b8d6acdacc # v2.2.10
-        with:
-          ocaml-compiler: 4.14.0
-
-      - name: Setup opam switch
-        run: |
-          opam switch create 4.14.0
-          echo "OPAM_SWITCH_PREFIX=$HOME/.opam/4.14.0" >> $GITHUB_ENV
-          echo "CAML_LD_LIBRARY_PATH=$HOME/.opam/4.14.0/lib/stublibs:$HOME/.opam/4.14.0/lib/ocaml/stublibs:$HOME/.opam/4.14.0/lib/ocam" >> $GITHUB_ENV
-          echo "$HOME/.opam/4.14.0/bin" >> $GITHUB_PATH
-          echo "/home/opam/.opam/4.14.0/bin" >> $GITHUB_PATH
+          sudo apt-get install opam
 
       - name: Build Pyre (and Pysa)
         run: |
+          echo ""
+          echo "--------- initializing switch --------"
+          ./scripts/setup.sh --only-initialize-switch
+          echo "--------- done initializing switch --------"
+          echo ""
+
+          echo "sanity check, these should be equal: /home/runner/.opam/pyre-4.14.0/bin ${HOME}/.opam/pyre-4.14.0/bin"
+          echo "ls /home/runner/.opam/pyre-4.14.0/bin ..."
+          ls /home/runner/.opam/pyre-4.14.0/bin || echo "(no such dir)"
+
+          echo ""
+          echo "--------- building ---------"
+          echo ""
+
           ./scripts/setup.sh --local --no-tests
           make -C source
           echo "PYTHONPATH=$GITHUB_WORKSPACE/..:$PYTHONPATH" >> $GITHUB_ENV

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -114,6 +114,7 @@ def _run_command(
     else:
         environment_variables = None
     LOG.info(command)
+    LOG.info("... env vars for ^^ are: %r", environment_variables)
     try:
         output = subprocess.check_output(
             command,
@@ -407,6 +408,10 @@ def setup(
     parser.add_argument("--build-type", type=BuildType)
     parser.add_argument("--no-tests", action="store_true")
     parser.add_argument("--rust-path", type=Path)
+    # Skip the build. This is mainly useful for debugging remote environment setup in CI,
+    # because if anything goes wrong that breaks the build, it will abort CI which
+    # makes investigations difficult.
+    parser.add_argument("--only-initialize-switch", action="store_true")
 
     parsed = parser.parse_args()
 
@@ -423,16 +428,17 @@ def setup(
         produce_dune_file(pyre_directory, build_type)
     else:
         initialize_opam_switch(opam_root, opam_version, release, add_environment_variables, parsed.rust_path)
-        full_setup(
-            opam_root,
-            opam_version,
-            pyre_directory,
-            release=release,
-            run_tests=not parsed.no_tests,
-            build_type=build_type,
-            add_environment_variables=add_environment_variables,
-            rust_path=parsed.rust_path,
-        )
+        if not parsed.only_initialize_switch:
+            full_setup(
+                opam_root,
+                opam_version,
+                pyre_directory,
+                release=release,
+                run_tests=not parsed.no_tests,
+                build_type=build_type,
+                add_environment_variables=add_environment_variables,
+                rust_path=parsed.rust_path,
+            )
 
 
 if __name__ == "__main__":

--- a/source/Makefile
+++ b/source/Makefile
@@ -6,6 +6,8 @@
 .PHONY: dev
 dev: configure
 	@../scripts/generate-version-number.sh development
+	echo "In makefile, env is... "
+	env
 	dune build @install -j auto --profile dev
 
 .PHONY: test


### PR DESCRIPTION
Summary:
The build in github is currently broken due to a dune version mismatch.

I think the problem is that our workflow is incorrectly getting `dune` from
an apt download rather than our opam switch; trying to see what happens if
we only apt install opam.

Differential Revision: D59591828
