### PR TITLE
remove unused intervaltree dependency

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -27,9 +27,6 @@
       "site-package": "graphql"
     },
     {
-      "site-package": "intervaltree"
-    },
-    {
       "site-package": "libcst"
     },
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 click>=8.0
 dataclasses-json==0.5.7
-intervaltree
 libcst
 psutil
 pyre-extensions>=0.0.29


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x ] `pre-commit run`

## Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

the library intervaltree seems to be not anymore used in the codebase but still defined as a dependency currently the latest version is broken https://github.com/chaimleib/intervaltree/issues/138 

solves #902 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
