### PR TITLE
Use pyre2/pyre2 as working directory for pyre2 github workflow

### DIFF
--- a/.github/workflows/pyre2.yml
+++ b/.github/workflows/pyre2.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
+    defaults:
+      run:
+        working-directory: ./pyre2/pyre2
+
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Summary:
The workflow is currently failing with "error: could not find `Cargo.toml` in `/home/runner/work/pyre-check/pyre-check` or any parent directory" (example: https://github.com/facebook/pyre-check/actions/runs/12285231821).

working-directory stuff copied from https://stackoverflow.com/a/63122434.

Differential Revision: D67113206


