### PR TITLE
Support both flask 2 and flask 3 DSL generator

### DIFF
--- a/documentation/deliberately_vulnerable_flask_app/requirements.txt
+++ b/documentation/deliberately_vulnerable_flask_app/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.0.3
+Flask==2.3.3
 lxml
 jsonpickle
 requests

--- a/stubs/third_party_taint/flask_sources_sinks.pysa
+++ b/stubs/third_party_taint/flask_sources_sinks.pysa
@@ -84,7 +84,10 @@ ModelQuery(
   name = "get_route_sources_sinks",
   find = "functions",
   where = [
-    Decorator(fully_qualified_callee.equals("flask.sansio.scaffold.Scaffold.route")),
+    AnyOf(
+      Decorator(fully_qualified_callee.equals("flask.sansio.scaffold.Scaffold.route")),
+      Decorator(fully_qualified_callee.equals("flask.scaffold.Scaffold.route"))
+    )
   ],
   model = [
     Parameters(TaintSource[UserControlled, UserControlled_Parameter]),
@@ -96,7 +99,10 @@ ModelQuery(
   name = "get_errorhandler_sinks",
   find = "functions",
   where = [
-    Decorator(fully_qualified_callee.equals("flask.sansio.scaffold.Scaffold.errorhandler")),
+    AnyOf(
+      Decorator(fully_qualified_callee.equals("flask.sansio.scaffold.Scaffold.errorhandler")),
+      Decorator(fully_qualified_callee.equals("flask.scaffold.Scaffold.errorhandler"))
+    )
   ],
   model = [
     Returns(TaintSink[ReturnedToUser])


### PR DESCRIPTION
Summary: Flask 3 moved the route decorators inside the sansio folder which required updating the model. However due to some pyre limitation we are not able to infer the type of aparrapo.route for flask 3 leading to False negative detection which makes the opensource test to fail. While we work on the fixing the false negative keeping the support for both flask 2 and 3.

Reviewed By: arthaud

Differential Revision: D68209629


