### PR TITLE
Updating README with a link to the next version of Pyre called Pyrefly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Gitter](https://badges.gitter.im/pyre-check/community.svg)](https://gitter.im/pyre-check/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+> [!IMPORTANT]
+>
+> ## New Version is Available
+>
+> Check out <a href="https://github.com/facebook/pyrefly">Pyrefly</a>, a fast type checker and IDE for Python.
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/facebook/pyre-check/main/logo.png">
 </p>


### PR DESCRIPTION
## Summary

Updating README with a link to the next version of Pyre called Pyrefly.

## Test Plan

README-only change, no tests necessary.