### PR TITLE
fix: use enum value for Click version option flag_value

### DIFF
--- a/client/pyre.py
+++ b/client/pyre.py
@@ -186,8 +186,8 @@ def _create_and_check_configuration(
     "--version",
     is_flag=False,
     type=click.Choice([kind.value for kind in command_arguments.VersionKind]),
-    flag_value=command_arguments.VersionKind.CLIENT_AND_BINARY,
-    default=command_arguments.VersionKind.NONE,
+    flag_value=command_arguments.VersionKind.CLIENT_AND_BINARY.value,
+    default=command_arguments.VersionKind.NONE.value,
     help="Print the versions of Pyre.",
 )
 @click.option("--debug/--no-debug", default=False, hidden=True)
@@ -426,8 +426,8 @@ def pyre(
     "--version",
     is_flag=False,
     type=click.Choice([kind.value for kind in command_arguments.VersionKind]),
-    flag_value=command_arguments.VersionKind.CLIENT_AND_BINARY,
-    default=command_arguments.VersionKind.NONE,
+    flag_value=command_arguments.VersionKind.CLIENT_AND_BINARY.value,
+    default=command_arguments.VersionKind.NONE.value,
     help="Print the versions of Pysa.",
 )
 @click.option(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

## Summary
The expectation in the click.option is a literal but it was getting an enum type, thus now we are passing value of enum. 

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
I was trying to setup pyre in my django project and i got the error as in sc.
![image](https://github.com/user-attachments/assets/43cf5b0b-5ca7-4137-95ba-b82b6a721e59)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
